### PR TITLE
Fix the bearer configuration and GPRS initialization sequence

### DIFF
--- a/examples/Tester/Tester.ino
+++ b/examples/Tester/Tester.ino
@@ -272,7 +272,9 @@ void sim() {
         Log.notice(S_F("SIM status : \"%s\"" NL), buffer);
     }
     else if(BUFFER_IS("UNLOCK")) {
-        size_t length = readNext();
+        readNext();
+        
+        size_t length = strlen(buffer);
         if(length != 4) {
             Log.error(S_F("4 digit pin code required" NL));
             return;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SIM808
-version=1.0.0
+version=1.0.1
 author=Bertrand Lemasle
 maintainer=Bertrand Lemasle
 sentence=Straightforward Arduino library for the SIM808

--- a/src/SIM808.Gprs.cpp
+++ b/src/SIM808.Gprs.cpp
@@ -57,8 +57,8 @@ bool SIM808::enableGprs(const char *apn, const char* user = NULL, const char *pa
 bool SIM808::disableGprs()
 {
 	return 
-		(sendAT(TO_F(TOKEN_CIPSHUT)), waitResponse(65000L, TO_F(TOKEN_SHUT_OK)) == 0) &&					//AT+CIPSHUT
 		(sendFormatAT(TO_F(AT_COMMAND_SET_BEARER_SETTING), 0, 1), waitResponse(65000L) != -1) &&			//AT+SAPBR=0,1
+		(sendAT(TO_F(TOKEN_CIPSHUT)), waitResponse(65000L, TO_F(TOKEN_SHUT_OK)) == 0) &&					//AT+CIPSHUT
 		(sendFormatAT(TO_F(AT_COMMAND_GPRS_ATTACH), 0), waitResponse(10000L) == 0);							//AT+CGATT=0
 }
 

--- a/src/SIM808.Gprs.cpp
+++ b/src/SIM808.Gprs.cpp
@@ -1,5 +1,6 @@
 #include "SIM808.h"
 
+AT_COMMAND(SET_BEARER_SETTING_CONTYPE_GPRS, "+SAPBR=3,1,\"CONTYPE\",\"GPRS\"");
 AT_COMMAND(SET_BEARER_SETTING, "+SAPBR=%d,%d");
 AT_COMMAND(GPRS_START_TASK, "+CSTT=\"%s\",\"%s\",\"%s\"");
 AT_COMMAND(GPRS_ATTACH, "+CGATT=%d");
@@ -29,6 +30,9 @@ bool SIM808::enableGprs(const char *apn, const char* user = NULL, const char *pa
 	return 
 		(sendAT(TO_F(TOKEN_CIPSHUT)), waitResponse(65000L, TO_F(TOKEN_SHUT_OK)) == 0) &&					//AT+CIPSHUT
 		(sendFormatAT(TO_F(AT_COMMAND_GPRS_ATTACH), 1), waitResponse(10000L) == 0) &&						//AT+CGATT=1
+
+		(sendFormatAT(TO_F(AT_COMMAND_SET_BEARER_SETTING), 0, 1), waitResponse(65000L) != -1) &&			//AT+SAPBR=0,1
+		(sendAT(TO_F(AT_COMMAND_SET_BEARER_SETTING_CONTYPE_GPRS)), waitResponse() == 0) && 					//AT+SAPBR=3,1,"CONTYPE","GPRS"
 
 		(sendFormatAT(TO_F(AT_COMMAND_GPRS_START_TASK), apn, user, password), waitResponse() == 0) &&		//AT+CSTT="apn","user","password"
 		(sendFormatAT(TO_F(AT_COMMAND_SET_BEARER_SETTING), 1, 1), waitResponse(65000L) == 0);				//AT+SAPBR=1,1

--- a/src/SIM808.h
+++ b/src/SIM808.h
@@ -46,6 +46,10 @@ private:
 	 * Terminate the HTTP service.
 	 */
 	bool httpEnd();
+	/**
+	 * Set one of the bearer settings for application based on IP.
+	 */
+	bool setBearerSetting(ATConstStr parameter, const char* value);
 
 public:
 	SIM808(uint8_t resetPin, uint8_t pwrKeyPin, uint8_t statusPin);


### PR DESCRIPTION
This PR fixes several issues with the GPRS initialization sequence that prevented the use of the HTTP methods, leading to `601` errors.