### PR TITLE
Platforms compatibitily enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: c
 env:
   global:
     - ARDUINO_IDE_VERSION="1.8.5"
+    - ARDUINO_ESP32_VERSION="1.0.1"
     - LIBRARY_NAME="SIM808"
+  matrix:
+    - BOARD="arduino:avr:uno"
+    - BOARD="esp32:esp3:pico32"
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
   - sleep 3
@@ -11,14 +15,16 @@ before_install:
   - tar xf arduino-$ARDUINO_IDE_VERSION-linux64.tar.xz
   - sudo mv arduino-$ARDUINO_IDE_VERSION /usr/local/share/arduino
   - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
+  - arduino --pref boardsmanager.additional.urls=https://dl.espressif.com/dl/package_esp32_index.json --save-prefs
+  - arduino --install-boards esp32:esp32:$ARDUINO_ESP32_VERSION
 install:
  - ln -s $PWD /usr/local/share/arduino/libraries/$LIBRARY_NAME
  - arduino --install-library "ArduinoLog"
 script:
- - arduino --verify --board arduino:avr:uno $PWD/examples/AcquireGPSPosition/AcquireGPSPosition.ino
- - arduino --verify --board arduino:avr:uno $PWD/examples/GeneralInformation/GeneralInformation.ino
- - arduino --verify --board arduino:avr:uno $PWD/examples/HttpPost/HttpPost.ino
- - arduino --verify --board arduino:avr:uno $PWD/examples/Tester/Tester.ino
+ - arduino --verify --board $BOARD $PWD/examples/AcquireGPSPosition/AcquireGPSPosition.ino
+ - arduino --verify --board $BOARD $PWD/examples/GeneralInformation/GeneralInformation.ino
+ - arduino --verify --board $BOARD $PWD/examples/HttpPost/HttpPost.ino
+ - arduino --verify --board $BOARD $PWD/examples/Tester/Tester.ino
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
     - ARDUINO_ESP32_VERSION="1.0.1"
     - LIBRARY_NAME="SIM808"
   matrix:
-    - BOARD="arduino:avr:uno"
-    - BOARD="esp32:esp3:pico32"
+    - ESP32=false BOARD="arduino:avr:uno"
+    - ESP32=true BOARD="esp32:esp32:pico32"
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
   - sleep 3
@@ -16,7 +16,7 @@ before_install:
   - sudo mv arduino-$ARDUINO_IDE_VERSION /usr/local/share/arduino
   - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
   - arduino --pref boardsmanager.additional.urls=https://dl.espressif.com/dl/package_esp32_index.json --save-prefs
-  - arduino --install-boards esp32:esp32:$ARDUINO_ESP32_VERSION
+  - if $ESP32 then; arduino --install-boards esp32:esp32:$ARDUINO_ESP32_VERSION; fi
 install:
  - ln -s $PWD /usr/local/share/arduino/libraries/$LIBRARY_NAME
  - arduino --install-library "ArduinoLog"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - sudo mv arduino-$ARDUINO_IDE_VERSION /usr/local/share/arduino
   - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
   - arduino --pref boardsmanager.additional.urls=https://dl.espressif.com/dl/package_esp32_index.json --save-prefs
-  - if $ESP32 then; arduino --install-boards esp32:esp32:$ARDUINO_ESP32_VERSION; fi
+  - if $ESP32; then arduino --install-boards esp32:esp32:$ARDUINO_ESP32_VERSION; fi
 install:
  - ln -s $PWD /usr/local/share/arduino/libraries/$LIBRARY_NAME
  - arduino --install-library "ArduinoLog"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It does *not* have the pretention to become the new SIM808 standard library, but
 
 #define SIM808_BAUDRATE 4800    ///< Control the baudrate use to communicate with the SIM808 module
 
-SoftwareSerial simSerial = SoftwareSerial(SIM_TX, SIM_RX)
+SoftwareSerial simSerial = SoftwareSerial(SIM_TX, SIM_RX);
 SIM808 sim808 = SIM808(SIM_RST, SIM_PWR, SIM_STATUS);
 // SIM808 sim808 = SIM808(SIM_RST); // if you only have the RESET pin wired
 // SIM808 sim808 = SIM808(SIM_RST, SIM_PWR); // if you only have the RESET and PWRKEY pins wired

--- a/examples/AcquireGPSPosition/AcquireGPSPosition.ino
+++ b/examples/AcquireGPSPosition/AcquireGPSPosition.ino
@@ -4,7 +4,16 @@
 
 #include <SIM808.h>
 #include <ArduinoLog.h>
-#include <SoftwareSerial.h>
+
+#if defined(__AVR__)
+    #include <SoftwareSerial.h>
+    #define SIM_SERIAL_TYPE	SoftwareSerial					///< Type of variable that holds the Serial communication with SIM808
+    #define SIM_SERIAL		SIM_SERIAL_TYPE(SIM_TX, SIM_RX)	///< Definition of the instance that holds the Serial communication with SIM808    
+#else
+    #include <HardwareSerial.h>
+    #define SIM_SERIAL_TYPE	HardwareSerial					///< Type of variable that holds the Serial communication with SIM808
+    #define SIM_SERIAL		SIM_SERIAL_TYPE(2)	            ///< Definition of the instance that holds the Serial communication with SIM808    
+#endif
 
 #define SIM_RST		5	///< SIM808 RESET
 #define SIM_RX		6	///< SIM808 RXD
@@ -20,7 +29,13 @@
 #define POSITION_SIZE   128     ///< Size of the position buffer
 #define NL  "\n"
 
-SoftwareSerial simSerial = SoftwareSerial(SIM_TX, SIM_RX);
+#if defined(__AVR__)
+    typedef __FlashStringHelper* __StrPtr;
+#else
+    typedef const char* __StrPtr;
+#endif
+
+SIM_SERIAL_TYPE simSerial = SIM_SERIAL;
 SIM808 sim808 = SIM808(SIM_RST, SIM_PWR, SIM_STATUS);
 char position[POSITION_SIZE];
 
@@ -50,7 +65,7 @@ void loop() {
 
     uint16_t sattelites;
     float lat, lon;
-    __FlashStringHelper * state;
+    __StrPtr state;
 
     if(status == SIM808GpsStatus::Fix) state = S_F("Normal");
     else state = S_F("Accurate");

--- a/examples/AcquireGPSPosition/AcquireGPSPosition.ino
+++ b/examples/AcquireGPSPosition/AcquireGPSPosition.ino
@@ -31,11 +31,11 @@ void setup() {
     simSerial.begin(SIM808_BAUDRATE);
     sim808.begin(simSerial);
 
-    Log.notice(F("Powering on SIM808..." NL));
+    Log.notice(S_F("Powering on SIM808..." NL));
     sim808.powerOnOff(true);
     sim808.init();
 
-    Log.notice(F("Powering on SIM808's GPS..." NL));
+    Log.notice(S_F("Powering on SIM808's GPS..." NL));
 	sim808.powerOnOffGps(true);
 }
 
@@ -43,7 +43,7 @@ void loop() {
     SIM808_GPS_STATUS status = sim808.getGpsStatus(position, POSITION_SIZE);
     
     if(status < SIM808_GPS_STATUS::FIX) {
-        Log.notice(F("No fix yet..." NL));
+        Log.notice(S_F("No fix yet..." NL));
         delay(NO_FIX_GPS_DELAY);
         return;
     }
@@ -59,11 +59,11 @@ void loop() {
     sim808.getGpsField(position, SIM808_GPS_FIELD::LATITUDE, &lat);
     sim808.getGpsField(position, SIM808_GPS_FIELD::LONGITUDE, &lon);
 
-    Log.notice(F("%s" NL), position);
-    Log.notice(F("Fix type: %S" NL), state);
-    Log.notice(F("Sattelites used : %d" NL), sattelites);
-    Log.notice(F("Latitude : %F" NL), lat);
-    Log.notice(F("Longitude : %F" NL), lon);
+    Log.notice(S_F("%s" NL), position);
+    Log.notice(S_F("Fix type: %S" NL), state);
+    Log.notice(S_F("Sattelites used : %d" NL), sattelites);
+    Log.notice(S_F("Latitude : %F" NL), lat);
+    Log.notice(S_F("Longitude : %F" NL), lon);
     
     delay(FIX_GPS_DELAY);
 }

--- a/examples/AcquireGPSPosition/AcquireGPSPosition.ino
+++ b/examples/AcquireGPSPosition/AcquireGPSPosition.ino
@@ -40,9 +40,9 @@ void setup() {
 }
 
 void loop() {
-    SIM808_GPS_STATUS status = sim808.getGpsStatus(position, POSITION_SIZE);
+    SIM808GpsStatus status = sim808.getGpsStatus(position, POSITION_SIZE);
     
-    if(status < SIM808_GPS_STATUS::FIX) {
+    if(status < SIM808GpsStatus::FIX) {
         Log.notice(S_F("No fix yet..." NL));
         delay(NO_FIX_GPS_DELAY);
         return;
@@ -52,12 +52,12 @@ void loop() {
     float lat, lon;
     __FlashStringHelper * state;
 
-    if(status == SIM808_GPS_STATUS::FIX) state = S_F("Normal");
+    if(status == SIM808GpsStatus::FIX) state = S_F("Normal");
     else state = S_F("Accurate");
 
-    sim808.getGpsField(position, SIM808_GPS_FIELD::GNSS_USED, &sattelites);
-    sim808.getGpsField(position, SIM808_GPS_FIELD::LATITUDE, &lat);
-    sim808.getGpsField(position, SIM808_GPS_FIELD::LONGITUDE, &lon);
+    sim808.getGpsField(position, SIM808GpsField::GNSS_USED, &sattelites);
+    sim808.getGpsField(position, SIM808GpsField::LATITUDE, &lat);
+    sim808.getGpsField(position, SIM808GpsField::LONGITUDE, &lon);
 
     Log.notice(S_F("%s" NL), position);
     Log.notice(S_F("Fix type: %S" NL), state);

--- a/examples/AcquireGPSPosition/AcquireGPSPosition.ino
+++ b/examples/AcquireGPSPosition/AcquireGPSPosition.ino
@@ -42,7 +42,7 @@ void setup() {
 void loop() {
     SIM808GpsStatus status = sim808.getGpsStatus(position, POSITION_SIZE);
     
-    if(status < SIM808GpsStatus::FIX) {
+    if(status < SIM808GpsStatus::Fix) {
         Log.notice(S_F("No fix yet..." NL));
         delay(NO_FIX_GPS_DELAY);
         return;
@@ -52,12 +52,12 @@ void loop() {
     float lat, lon;
     __FlashStringHelper * state;
 
-    if(status == SIM808GpsStatus::FIX) state = S_F("Normal");
+    if(status == SIM808GpsStatus::Fix) state = S_F("Normal");
     else state = S_F("Accurate");
 
-    sim808.getGpsField(position, SIM808GpsField::GNSS_USED, &sattelites);
-    sim808.getGpsField(position, SIM808GpsField::LATITUDE, &lat);
-    sim808.getGpsField(position, SIM808GpsField::LONGITUDE, &lon);
+    sim808.getGpsField(position, SIM808GpsField::GnssUsed, &sattelites);
+    sim808.getGpsField(position, SIM808GpsField::Latitude, &lat);
+    sim808.getGpsField(position, SIM808GpsField::Longitude, &lon);
 
     Log.notice(S_F("%s" NL), position);
     Log.notice(S_F("Fix type: %S" NL), state);

--- a/examples/GeneralInformation/GeneralInformation.ino
+++ b/examples/GeneralInformation/GeneralInformation.ino
@@ -31,15 +31,15 @@ void setup() {
     simSerial.begin(SIM808_BAUDRATE);
     sim808.begin(simSerial);
 
-    Log.notice(F("Powering on SIM808..." NL));
+    Log.notice(S_F("Powering on SIM808..." NL));
     sim808.powerOnOff(true);
     sim808.init();
 
     sim808.getImei(buffer, BUFFER_SIZE);
-    Log.notice(F("IMEI : \"%s\"" NL), buffer);
+    Log.notice(S_F("IMEI : \"%s\"" NL), buffer);
 
     sim808.getSimState(buffer, BUFFER_SIZE);
-    Log.notice(F("SIM card state : \"%s\"" NL), buffer);
+    Log.notice(S_F("SIM card state : \"%s\"" NL), buffer);
 
     SIM808ChargingStatus charging = sim808.getChargingState();
     switch(charging.state) {
@@ -56,11 +56,11 @@ void setup() {
         strcpy_P(buffer, PSTR("NOT_CHARGING"));
         break;
     }
-    Log.notice(F("Charging state : %s, %d%% @ %dmV" NL), buffer, charging.level, charging.voltage);
+    Log.notice(S_F("Charging state : %s, %d%% @ %dmV" NL), buffer, charging.level, charging.voltage);
 
     //you can also send unimplemented simple commands
     sim808.sendCommand("I", buffer, BUFFER_SIZE);
-    Log.notice(F("ATI response : \"%s\"" NL), buffer);
+    Log.notice(S_F("ATI response : \"%s\"" NL), buffer);
 }
 
 void loop() { }

--- a/examples/GeneralInformation/GeneralInformation.ino
+++ b/examples/GeneralInformation/GeneralInformation.ino
@@ -43,16 +43,16 @@ void setup() {
 
     SIM808ChargingStatus charging = sim808.getChargingState();
     switch(charging.state) {
-        case SIM808_CHARGING_STATE::CHARGING:
+        case SIM808ChargingState::CHARGING:
         strcpy_P(buffer, PSTR("CHARGING"));
         break;
-        case SIM808_CHARGING_STATE::CHARGING_DONE:
+        case SIM808ChargingState::CHARGING_DONE:
         strcpy_P(buffer, PSTR("CHARGING_DONE"));
         break;
-        case SIM808_CHARGING_STATE::ERROR:
+        case SIM808ChargingState::ERROR:
         strcpy_P(buffer, PSTR("ERROR"));
         break;
-        case SIM808_CHARGING_STATE::NOT_CHARGING:
+        case SIM808ChargingState::NOT_CHARGING:
         strcpy_P(buffer, PSTR("NOT_CHARGING"));
         break;
     }

--- a/examples/GeneralInformation/GeneralInformation.ino
+++ b/examples/GeneralInformation/GeneralInformation.ino
@@ -4,7 +4,20 @@
 
 #include <SIM808.h>
 #include <ArduinoLog.h>
-#include <SoftwareSerial.h>
+
+#if defined(__AVR__)
+    #include <SoftwareSerial.h>
+    #define SIM_SERIAL_TYPE	SoftwareSerial					///< Type of variable that holds the Serial communication with SIM808
+    #define SIM_SERIAL		SIM_SERIAL_TYPE(SIM_TX, SIM_RX)	///< Definition of the instance that holds the Serial communication with SIM808    
+    
+    #define STRLCPY_P(s1, s2) strlcpy_P(s1, s2, BUFFER_SIZE)
+#else
+    #include <HardwareSerial.h>
+    #define SIM_SERIAL_TYPE	HardwareSerial					///< Type of variable that holds the Serial communication with SIM808
+    #define SIM_SERIAL		SIM_SERIAL_TYPE(2)	            ///< Definition of the instance that holds the Serial communication with SIM808    
+    
+    #define STRLCPY_P(s1, s2) strlcpy(s1, s2, BUFFER_SIZE)
+#endif
 
 #define SIM_RST		5	///< SIM808 RESET
 #define SIM_RX		6	///< SIM808 RXD
@@ -19,7 +32,7 @@
 #define BUFFER_SIZE 512         ///< Size of the buffer
 #define NL  "\n"
 
-SoftwareSerial simSerial = SoftwareSerial(SIM_TX, SIM_RX);
+SIM_SERIAL_TYPE simSerial = SIM_SERIAL;
 SIM808 sim808 = SIM808(SIM_RST, SIM_PWR, SIM_STATUS);
 bool done = false;
 char buffer[BUFFER_SIZE];
@@ -44,16 +57,16 @@ void setup() {
     SIM808ChargingStatus charging = sim808.getChargingState();
     switch(charging.state) {
         case SIM808ChargingState::Charging:
-        strcpy_P(buffer, PSTR("Charging"));
+            STRLCPY_P(buffer, PSTR("Charging"));
         break;
         case SIM808ChargingState::ChargingDone:
-        strcpy_P(buffer, PSTR("ChargingDone"));
+            STRLCPY_P(buffer, PSTR("ChargingDone"));
         break;
         case SIM808ChargingState::Error:
-        strcpy_P(buffer, PSTR("Error"));
+            STRLCPY_P(buffer, PSTR("Error"));
         break;
         case SIM808ChargingState::NotCharging:
-        strcpy_P(buffer, PSTR("NotCharging"));
+            STRLCPY_P(buffer, PSTR("NotCharging"));
         break;
     }
     Log.notice(S_F("Charging state : %s, %d%% @ %dmV" NL), buffer, charging.level, charging.voltage);

--- a/examples/GeneralInformation/GeneralInformation.ino
+++ b/examples/GeneralInformation/GeneralInformation.ino
@@ -44,16 +44,16 @@ void setup() {
     SIM808ChargingStatus charging = sim808.getChargingState();
     switch(charging.state) {
         case SIM808ChargingState::Charging:
-        strcpy_P(buffer, PSTR("CHARGING"));
+        strcpy_P(buffer, PSTR("Charging"));
         break;
         case SIM808ChargingState::ChargingDone:
-        strcpy_P(buffer, PSTR("CHARGING_DONE"));
+        strcpy_P(buffer, PSTR("ChargingDone"));
         break;
         case SIM808ChargingState::Error:
-        strcpy_P(buffer, PSTR("ERROR"));
+        strcpy_P(buffer, PSTR("Error"));
         break;
         case SIM808ChargingState::NotCharging:
-        strcpy_P(buffer, PSTR("NOT_CHARGING"));
+        strcpy_P(buffer, PSTR("NotCharging"));
         break;
     }
     Log.notice(S_F("Charging state : %s, %d%% @ %dmV" NL), buffer, charging.level, charging.voltage);

--- a/examples/GeneralInformation/GeneralInformation.ino
+++ b/examples/GeneralInformation/GeneralInformation.ino
@@ -43,16 +43,16 @@ void setup() {
 
     SIM808ChargingStatus charging = sim808.getChargingState();
     switch(charging.state) {
-        case SIM808ChargingState::CHARGING:
+        case SIM808ChargingState::Charging:
         strcpy_P(buffer, PSTR("CHARGING"));
         break;
-        case SIM808ChargingState::CHARGING_DONE:
+        case SIM808ChargingState::ChargingDone:
         strcpy_P(buffer, PSTR("CHARGING_DONE"));
         break;
-        case SIM808ChargingState::ERROR:
+        case SIM808ChargingState::Error:
         strcpy_P(buffer, PSTR("ERROR"));
         break;
-        case SIM808ChargingState::NOT_CHARGING:
+        case SIM808ChargingState::NotCharging:
         strcpy_P(buffer, PSTR("NOT_CHARGING"));
         break;
     }

--- a/examples/HttpPost/HttpPost.ino
+++ b/examples/HttpPost/HttpPost.ino
@@ -46,11 +46,11 @@ void loop() {
         return;
     }
 
-    SIM808_NETWORK_REGISTRATION_STATE status = sim808.getNetworkRegistrationStatus();
+    SIM808NetworkRegistrationState status = sim808.getNetworkRegistrationStatus();
     SIM808SignalQualityReport report = sim808.getSignalQuality();
 
     bool isAvailable = static_cast<int8_t>(status) &
-        (static_cast<int8_t>(SIM808_NETWORK_REGISTRATION_STATE::REGISTERED) | static_cast<int8_t>(SIM808_NETWORK_REGISTRATION_STATE::ROAMING))
+        (static_cast<int8_t>(SIM808NetworkRegistrationState::REGISTERED) | static_cast<int8_t>(SIM808NetworkRegistrationState::ROAMING))
         != 0;
 
     if(!isAvailable) {

--- a/examples/HttpPost/HttpPost.ino
+++ b/examples/HttpPost/HttpPost.ino
@@ -35,7 +35,7 @@ void setup() {
     simSerial.begin(SIM808_BAUDRATE);
     sim808.begin(simSerial);
 
-    Log.notice(F("Powering on SIM808..." NL));
+    Log.notice(S_F("Powering on SIM808..." NL));
     sim808.powerOnOff(true);
     sim808.init();    
 }
@@ -54,26 +54,26 @@ void loop() {
         != 0;
 
     if(!isAvailable) {
-        Log.notice(F("No network yet..." NL));
+        Log.notice(S_F("No network yet..." NL));
         delay(NETWORK_DELAY);
         return;
     }
 
-    Log.notice(F("Network is ready." NL));
-    Log.notice(F("Attenuation : %d dBm, Estimated quality : %d" NL), report.attenuation, report.rssi);
+    Log.notice(S_F("Network is ready." NL));
+    Log.notice(S_F("Attenuation : %d dBm, Estimated quality : %d" NL), report.attenuation, report.rssi);
 
     bool enabled = false;
 	do {
-        Log.notice(F("Powering on SIM808's GPRS..." NL));
+        Log.notice(S_F("Powering on SIM808's GPRS..." NL));
         enabled = sim808.enableGprs(GPRS_APN, GPRS_USER, GPRS_PASS);        
     } while(!enabled);
     
-    Log.notice(F("Sending HTTP request..." NL));
+    Log.notice(S_F("Sending HTTP request..." NL));
     strncpy_P(buffer, PSTR("This is the body"), BUFFER_SIZE);
     //notice that we're using the same buffer for both body and response
-    uint16_t responseCode = sim808.httpPost("http://httpbin.org/anything", F("text/plain"), buffer, buffer, BUFFER_SIZE);
+    uint16_t responseCode = sim808.httpPost("http://httpbin.org/anything", S_F("text/plain"), buffer, buffer, BUFFER_SIZE);
 
-    Log.notice(F("Server responsed : %d" NL), responseCode);
+    Log.notice(S_F("Server responsed : %d" NL), responseCode);
     Log.notice(buffer);
 
     done = true;

--- a/examples/HttpPost/HttpPost.ino
+++ b/examples/HttpPost/HttpPost.ino
@@ -4,7 +4,20 @@
 
 #include <SIM808.h>
 #include <ArduinoLog.h>
-#include <SoftwareSerial.h>
+
+#if defined(__AVR__)
+    #include <SoftwareSerial.h>
+    #define SIM_SERIAL_TYPE	SoftwareSerial					///< Type of variable that holds the Serial communication with SIM808
+    #define SIM_SERIAL		SIM_SERIAL_TYPE(SIM_TX, SIM_RX)	///< Definition of the instance that holds the Serial communication with SIM808    
+    
+    #define STRLCPY_P(s1, s2) strlcpy_P(s1, s2, BUFFER_SIZE)
+#else
+    #include <HardwareSerial.h>
+    #define SIM_SERIAL_TYPE	HardwareSerial					///< Type of variable that holds the Serial communication with SIM808
+    #define SIM_SERIAL		SIM_SERIAL_TYPE(2)	            ///< Definition of the instance that holds the Serial communication with SIM808    
+    
+    #define STRLCPY_P(s1, s2) strlcpy(s1, s2, BUFFER_SIZE)
+#endif
 
 #define SIM_RST		5	///< SIM808 RESET
 #define SIM_RX		6	///< SIM808 RXD
@@ -23,7 +36,7 @@
 #define BUFFER_SIZE 512         ///< Side of the response buffer
 #define NL  "\n"
 
-SoftwareSerial simSerial = SoftwareSerial(SIM_TX, SIM_RX);
+SIM_SERIAL_TYPE simSerial = SIM_SERIAL;
 SIM808 sim808 = SIM808(SIM_RST, SIM_PWR, SIM_STATUS);
 bool done = false;
 char buffer[BUFFER_SIZE];
@@ -69,7 +82,7 @@ void loop() {
     } while(!enabled);
     
     Log.notice(S_F("Sending HTTP request..." NL));
-    strncpy_P(buffer, PSTR("This is the body"), BUFFER_SIZE);
+    STRLCPY_P(buffer, PSTR("This is the body"));
     //notice that we're using the same buffer for both body and response
     uint16_t responseCode = sim808.httpPost("http://httpbin.org/anything", S_F("text/plain"), buffer, buffer, BUFFER_SIZE);
 

--- a/examples/HttpPost/HttpPost.ino
+++ b/examples/HttpPost/HttpPost.ino
@@ -50,7 +50,7 @@ void loop() {
     SIM808SignalQualityReport report = sim808.getSignalQuality();
 
     bool isAvailable = static_cast<int8_t>(status) &
-        (static_cast<int8_t>(SIM808NetworkRegistrationState::REGISTERED) | static_cast<int8_t>(SIM808NetworkRegistrationState::ROAMING))
+        (static_cast<int8_t>(SIM808NetworkRegistrationState::Registered) | static_cast<int8_t>(SIM808NetworkRegistrationState::Roaming))
         != 0;
 
     if(!isAvailable) {

--- a/examples/Tester/Tester.ino
+++ b/examples/Tester/Tester.ino
@@ -56,7 +56,7 @@ const char NETWORK[] S_PROGMEM = "NETWORK";
 
 const char MINIMUM[] S_PROGMEM = "MINIMUM";
 const char FULL[] S_PROGMEM = "FULL";
-const char DISABLED[] S_PROGMEM = "DISABLED";
+const char RF_DISABLED[] S_PROGMEM = "RF_DISABLED";
 
 const char SEND[] S_PROGMEM = "SEND";
 const char DEFAULT_URL[] S_PROGMEM = "http://httpbin.org/anything";
@@ -89,7 +89,7 @@ void usage() {
     PRINT_LN("");
 
     PRINT_LN("network functionality\t\t\t\tGet the current network functionality");
-    PRINT_LN("network functionality [minimum|full|disabled]\tSet the current network functionality");
+    PRINT_LN("network functionality [minimum|full|rf_disabled]\tSet the current network functionality");
     PRINT_LN("network status\t\t\t\t\tGet the current network status");
     PRINT_LN("network quality\t\t\t\t\tGet the current network quality report");
 
@@ -352,8 +352,8 @@ void network() {
                 case SIM808_PHONE_FUNCTIONALITY::FULL:
                     state = TO_F(FULL);
                     break;
-                case SIM808_PHONE_FUNCTIONALITY::DISABLED:
-                    state = TO_F(DISABLED);
+                case SIM808_PHONE_FUNCTIONALITY::RF_DISABLED:
+                    state = TO_F(RF_DISABLED);
                     break;
                 default:
                     state = TO_F(UNKNOWN);
@@ -368,7 +368,7 @@ void network() {
             readNext();
             if(BUFFER_IS_P(MINIMUM)) fun = SIM808_PHONE_FUNCTIONALITY::MINIMUM;
             else if(BUFFER_IS_P(FULL)) fun = SIM808_PHONE_FUNCTIONALITY::FULL;
-            else if(BUFFER_IS_P(DISABLED)) fun = SIM808_PHONE_FUNCTIONALITY::DISABLED;
+            else if(BUFFER_IS_P(RF_DISABLED)) fun = SIM808_PHONE_FUNCTIONALITY::RF_DISABLED;
             else {
                 unrecognized();
                 return;

--- a/examples/Tester/Tester.ino
+++ b/examples/Tester/Tester.ino
@@ -23,8 +23,8 @@
     #define BUFFER_IS(s) STRING_IS(buffer, s)
     #define BUFFER_IS_P(s) strcasecmp_P(buffer, s) == 0
 
-    #define PRINT(s) Serial.print(F(s))
-    #define PRINT_LN(s) Serial.println(F(s))
+    #define PRINT(s) Serial.print(S_F(s))
+    #define PRINT_LN(s) Serial.println(S_F(s))
 #else
     #define BUFFER_IS(s) strcasecmp(buffer, s) == 0
     #define BUFFER_IS(s) STRING_IS(buffer, s)
@@ -550,7 +550,7 @@ void setup() {
     simSerial.begin(SIM808_BAUDRATE);
     sim808.begin(simSerial);
 
-    Log.notice(F("Powering on SIM808..." NL));
+    Log.notice(S_F("Powering on SIM808..." NL));
     sim808.powerOnOff(true);
     sim808.init();
 
@@ -575,5 +575,5 @@ void loop() {
         return;
     }
 
-    Log.notice(F("Done" NL));
+    Log.notice(S_F("Done" NL));
 }

--- a/examples/Tester/Tester.ino
+++ b/examples/Tester/Tester.ino
@@ -38,27 +38,27 @@
 const char UNRECOGNIZED[] S_PROGMEM = "Unrecognized : %s" NL;
 const char UNKNOWN[] S_PROGMEM = "Unknown value";
 
-const char YES[] S_PROGMEM = "YES";
-const char NO[] S_PROGMEM = "NO";
+const char YES[] S_PROGMEM = "Yes";
+const char NO[] S_PROGMEM = "No";
 
-const char SUCCESS[] S_PROGMEM = "SUCCESS";
-const char FAILED[] S_PROGMEM = "FAILED";
-const char ERROR[] S_PROGMEM = "ERROR";
+const char SUCCESS[] S_PROGMEM = "Success";
+const char FAILED[] S_PROGMEM = "Failed";
+const char ERROR[] S_PROGMEM = "Error";
 
-const char ON[] S_PROGMEM = "ON";
-const char OFF[] S_PROGMEM = "OFF";
-const char STATUS[] S_PROGMEM = "STATUS";
-const char ALL[] S_PROGMEM = "ALL";
+const char ON[] S_PROGMEM = "On";
+const char OFF[] S_PROGMEM = "Off";
+const char STATUS[] S_PROGMEM = "Status";
+const char ALL[] S_PROGMEM = "All";
 
-const char MAIN[] S_PROGMEM = "MAIN";
-const char GPS[] S_PROGMEM = "GPS";
-const char NETWORK[] S_PROGMEM = "NETWORK";
+const char MAIN[] S_PROGMEM = "Main";
+const char GPS[] S_PROGMEM = "Gps";
+const char NETWORK[] S_PROGMEM = "Network";
 
-const char MINIMUM[] S_PROGMEM = "MINIMUM";
-const char FULL[] S_PROGMEM = "FULL";
-const char RF_DISABLED[] S_PROGMEM = "DISABLED";
+const char MINIMUM[] S_PROGMEM = "Minimum";
+const char FULL[] S_PROGMEM = "Full";
+const char RF_DISABLED[] S_PROGMEM = "Disabled";
 
-const char SEND[] S_PROGMEM = "SEND";
+const char SEND[] S_PROGMEM = "Send";
 const char DEFAULT_URL[] S_PROGMEM = "http://httpbin.org/anything";
 
 SoftwareSerial simSerial = SoftwareSerial(SIM_TX, SIM_RX);
@@ -245,13 +245,13 @@ void charge() {
             state = TO_F(ERROR);
             break;
         case SIM808ChargingState::NotCharging:
-            state = S_F("NOT_CHARGING");
+            state = S_F("NotCharging");
             break;
         case SIM808ChargingState::Charging:
-            state = S_F("CHARGING");
+            state = S_F("Charging");
             break;
         case SIM808ChargingState::ChargingDone:
-            state = S_F("CHARGING_DONE");
+            state = S_F("ChargingDone");
             break;
         default:
             state = TO_F(UNKNOWN);
@@ -306,22 +306,22 @@ void network() {
                 state = TO_F(ERROR);
                 break;
             case SIM808NetworkRegistrationState::NotSearching:
-                state = S_F("NOT_SEARCHING");
+                state = S_F("NotSearching");
                 break;
             case SIM808NetworkRegistrationState::Registered:
-                state = S_F("REGISTERED");
+                state = S_F("Registered");
                 break;
             case SIM808NetworkRegistrationState::Searching:
-                state = S_F("SEARCHING");
+                state = S_F("Searching");
                 break;
             case SIM808NetworkRegistrationState::Denied:
-                state = S_F("DENIED");
+                state = S_F("Denied");
                 break;
             case SIM808NetworkRegistrationState::Unknown:
-                state = S_F("UNKNOWN");
+                state = S_F("Unknown");
                 break;
             case SIM808NetworkRegistrationState::Roaming:
-                state = S_F("ROAMING");
+                state = S_F("Roaming");
                 break;
             default:
                 state = TO_F(UNKNOWN);
@@ -408,13 +408,13 @@ void gps() {
                 state = TO_F(OFF);
                 break;
             case SIM808GpsStatus::NoFix:
-                state = S_F("NO_FIX");
+                state = S_F("NoFix");
                 break;
             case SIM808GpsStatus::Fix:
-                state = S_F("FIX");
+                state = S_F("Fix");
                 break;
             case SIM808GpsStatus::AccurateFix:
-                state = S_F("ACCURATE_FIX");
+                state = S_F("AccurateFix");
                 break;
             default:
                 state = TO_F(UNKNOWN);

--- a/examples/Tester/Tester.ino
+++ b/examples/Tester/Tester.ino
@@ -241,16 +241,16 @@ void charge() {
     __FlashStringHelper * state;
 
     switch(status.state) {
-        case SIM808_CHARGING_STATE::ERROR:
+        case SIM808ChargingState::ERROR:
             state = TO_F(ERROR);
             break;
-        case SIM808_CHARGING_STATE::NOT_CHARGING:
+        case SIM808ChargingState::NOT_CHARGING:
             state = S_F("NOT_CHARGING");
             break;
-        case SIM808_CHARGING_STATE::CHARGING:
+        case SIM808ChargingState::CHARGING:
             state = S_F("CHARGING");
             break;
-        case SIM808_CHARGING_STATE::CHARGING_DONE:
+        case SIM808ChargingState::CHARGING_DONE:
             state = S_F("CHARGING_DONE");
             break;
         default:
@@ -299,28 +299,28 @@ void network() {
     __FlashStringHelper * state;
 
     if(BUFFER_IS_P(STATUS)) {
-        SIM808_NETWORK_REGISTRATION_STATE status = sim808.getNetworkRegistrationStatus();
+        SIM808NetworkRegistrationState status = sim808.getNetworkRegistrationStatus();
 
         switch(status) {
-            case SIM808_NETWORK_REGISTRATION_STATE::ERROR:
+            case SIM808NetworkRegistrationState::ERROR:
                 state = TO_F(ERROR);
                 break;
-            case SIM808_NETWORK_REGISTRATION_STATE::NOT_SEARCHING:
+            case SIM808NetworkRegistrationState::NOT_SEARCHING:
                 state = S_F("NOT_SEARCHING");
                 break;
-            case SIM808_NETWORK_REGISTRATION_STATE::REGISTERED:
+            case SIM808NetworkRegistrationState::REGISTERED:
                 state = S_F("REGISTERED");
                 break;
-            case SIM808_NETWORK_REGISTRATION_STATE::SEARCHING:
+            case SIM808NetworkRegistrationState::SEARCHING:
                 state = S_F("SEARCHING");
                 break;
-            case SIM808_NETWORK_REGISTRATION_STATE::DENIED:
+            case SIM808NetworkRegistrationState::DENIED:
                 state = S_F("DENIED");
                 break;
-            case SIM808_NETWORK_REGISTRATION_STATE::UNKNOWN:
+            case SIM808NetworkRegistrationState::UNKNOWN:
                 state = S_F("UNKNOWN");
                 break;
-            case SIM808_NETWORK_REGISTRATION_STATE::ROAMING:
+            case SIM808NetworkRegistrationState::ROAMING:
                 state = S_F("ROAMING");
                 break;
             default:
@@ -341,18 +341,18 @@ void network() {
     }
     else if(BUFFER_IS("FUNCTIONALITY")) {
         if(last) { //get
-            SIM808_PHONE_FUNCTIONALITY fun = sim808.getPhoneFunctionality();
+            SIM808PhoneFunctionality fun = sim808.getPhoneFunctionality();
             switch(fun) {
-                case SIM808_PHONE_FUNCTIONALITY::FAIL:
+                case SIM808PhoneFunctionality::FAIL:
                     state = TO_F(FAILED);
                     break;
-                case SIM808_PHONE_FUNCTIONALITY::MINIMUM:
+                case SIM808PhoneFunctionality::MINIMUM:
                     state = TO_F(MINIMUM);
                     break;
-                case SIM808_PHONE_FUNCTIONALITY::FULL:
+                case SIM808PhoneFunctionality::FULL:
                     state = TO_F(FULL);
                     break;
-                case SIM808_PHONE_FUNCTIONALITY::RF_DISABLED:
+                case SIM808PhoneFunctionality::RF_DISABLED:
                     state = TO_F(RF_DISABLED);
                     break;
                 default:
@@ -363,12 +363,12 @@ void network() {
             Log.notice(S_F("phone functionality : %S" NL), state);
         }
         else {
-            SIM808_PHONE_FUNCTIONALITY fun;
+            SIM808PhoneFunctionality fun;
 
             readNext();
-            if(BUFFER_IS_P(MINIMUM)) fun = SIM808_PHONE_FUNCTIONALITY::MINIMUM;
-            else if(BUFFER_IS_P(FULL)) fun = SIM808_PHONE_FUNCTIONALITY::FULL;
-            else if(BUFFER_IS_P(RF_DISABLED)) fun = SIM808_PHONE_FUNCTIONALITY::RF_DISABLED;
+            if(BUFFER_IS_P(MINIMUM)) fun = SIM808PhoneFunctionality::MINIMUM;
+            else if(BUFFER_IS_P(FULL)) fun = SIM808PhoneFunctionality::FULL;
+            else if(BUFFER_IS_P(RF_DISABLED)) fun = SIM808PhoneFunctionality::RF_DISABLED;
             else {
                 unrecognized();
                 return;
@@ -397,23 +397,23 @@ void gps() {
         uint16_t tmpInt;
         bool oneField;
 
-        SIM808_GPS_STATUS status = sim808.getGpsStatus(position, 128);
+        SIM808GpsStatus status = sim808.getGpsStatus(position, 128);
         __FlashStringHelper * state;
 
         switch(status) {
-            case SIM808_GPS_STATUS::FAIL:
+            case SIM808GpsStatus::FAIL:
                 state = TO_F(FAILED);
                 break;
-            case SIM808_GPS_STATUS::OFF:
+            case SIM808GpsStatus::OFF:
                 state = TO_F(OFF);
                 break;
-            case SIM808_GPS_STATUS::NO_FIX:
+            case SIM808GpsStatus::NO_FIX:
                 state = S_F("NO_FIX");
                 break;
-            case SIM808_GPS_STATUS::FIX:
+            case SIM808GpsStatus::FIX:
                 state = S_F("FIX");
                 break;
-            case SIM808_GPS_STATUS::ACCURATE_FIX:
+            case SIM808GpsStatus::ACCURATE_FIX:
                 state = S_F("ACCURATE_FIX");
                 break;
             default:
@@ -426,49 +426,49 @@ void gps() {
         readNext();
         if(BUFFER_IS_P(ALL) || BUFFER_IS("TIME")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808_GPS_FIELD::UTC, &timeStr);
+            sim808.getGpsField(position, SIM808GpsField::UTC, &timeStr);
             Log.notice(S_F("time\t\t\t: %s" NL), timeStr);
         }
         
         if(BUFFER_IS_P(ALL) || BUFFER_IS("LAT")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808_GPS_FIELD::LATITUDE, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::LATITUDE, &tmpFloat);
             Log.notice(S_F("latitude\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("LON")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808_GPS_FIELD::LONGITUDE, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::LONGITUDE, &tmpFloat);
             Log.notice(S_F("longitude\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("ALT")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808_GPS_FIELD::ALTITUDE, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::ALTITUDE, &tmpFloat);
             Log.notice(S_F("altitude\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("SPEED")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808_GPS_FIELD::SPEED, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::SPEED, &tmpFloat);
             Log.notice(S_F("speed\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("COURSE")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808_GPS_FIELD::COURSE, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::COURSE, &tmpFloat);
             Log.notice(S_F("course\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("SATVIEW")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808_GPS_FIELD::GPS_IN_VIEW, &tmpInt);
+            sim808.getGpsField(position, SIM808GpsField::GPS_IN_VIEW, &tmpInt);
             Log.notice(S_F("satellites in view\t: %d" NL), tmpInt);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("SATUSED")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808_GPS_FIELD::GNSS_USED, &tmpInt);
+            sim808.getGpsField(position, SIM808GpsField::GNSS_USED, &tmpInt);
             Log.notice(S_F("satellites used\t: %d" NL), tmpInt);
         }
 

--- a/examples/Tester/Tester.ino
+++ b/examples/Tester/Tester.ino
@@ -56,7 +56,7 @@ const char NETWORK[] S_PROGMEM = "NETWORK";
 
 const char MINIMUM[] S_PROGMEM = "MINIMUM";
 const char FULL[] S_PROGMEM = "FULL";
-const char RF_DISABLED[] S_PROGMEM = "RF_DISABLED";
+const char RF_DISABLED[] S_PROGMEM = "DISABLED";
 
 const char SEND[] S_PROGMEM = "SEND";
 const char DEFAULT_URL[] S_PROGMEM = "http://httpbin.org/anything";
@@ -89,7 +89,7 @@ void usage() {
     PRINT_LN("");
 
     PRINT_LN("network functionality\t\t\t\tGet the current network functionality");
-    PRINT_LN("network functionality [minimum|full|rf_disabled]\tSet the current network functionality");
+    PRINT_LN("network functionality [minimum|full|disabled]\tSet the current network functionality");
     PRINT_LN("network status\t\t\t\t\tGet the current network status");
     PRINT_LN("network quality\t\t\t\t\tGet the current network quality report");
 
@@ -241,16 +241,16 @@ void charge() {
     __FlashStringHelper * state;
 
     switch(status.state) {
-        case SIM808ChargingState::ERROR:
+        case SIM808ChargingState::Error:
             state = TO_F(ERROR);
             break;
-        case SIM808ChargingState::NOT_CHARGING:
+        case SIM808ChargingState::NotCharging:
             state = S_F("NOT_CHARGING");
             break;
-        case SIM808ChargingState::CHARGING:
+        case SIM808ChargingState::Charging:
             state = S_F("CHARGING");
             break;
-        case SIM808ChargingState::CHARGING_DONE:
+        case SIM808ChargingState::ChargingDone:
             state = S_F("CHARGING_DONE");
             break;
         default:
@@ -302,25 +302,25 @@ void network() {
         SIM808NetworkRegistrationState status = sim808.getNetworkRegistrationStatus();
 
         switch(status) {
-            case SIM808NetworkRegistrationState::ERROR:
+            case SIM808NetworkRegistrationState::Error:
                 state = TO_F(ERROR);
                 break;
-            case SIM808NetworkRegistrationState::NOT_SEARCHING:
+            case SIM808NetworkRegistrationState::NotSearching:
                 state = S_F("NOT_SEARCHING");
                 break;
-            case SIM808NetworkRegistrationState::REGISTERED:
+            case SIM808NetworkRegistrationState::Registered:
                 state = S_F("REGISTERED");
                 break;
-            case SIM808NetworkRegistrationState::SEARCHING:
+            case SIM808NetworkRegistrationState::Searching:
                 state = S_F("SEARCHING");
                 break;
-            case SIM808NetworkRegistrationState::DENIED:
+            case SIM808NetworkRegistrationState::Denied:
                 state = S_F("DENIED");
                 break;
-            case SIM808NetworkRegistrationState::UNKNOWN:
+            case SIM808NetworkRegistrationState::Unknown:
                 state = S_F("UNKNOWN");
                 break;
-            case SIM808NetworkRegistrationState::ROAMING:
+            case SIM808NetworkRegistrationState::Roaming:
                 state = S_F("ROAMING");
                 break;
             default:
@@ -343,16 +343,16 @@ void network() {
         if(last) { //get
             SIM808PhoneFunctionality fun = sim808.getPhoneFunctionality();
             switch(fun) {
-                case SIM808PhoneFunctionality::FAIL:
+                case SIM808PhoneFunctionality::Fail:
                     state = TO_F(FAILED);
                     break;
-                case SIM808PhoneFunctionality::MINIMUM:
+                case SIM808PhoneFunctionality::Minimum:
                     state = TO_F(MINIMUM);
                     break;
-                case SIM808PhoneFunctionality::FULL:
+                case SIM808PhoneFunctionality::Full:
                     state = TO_F(FULL);
                     break;
-                case SIM808PhoneFunctionality::RF_DISABLED:
+                case SIM808PhoneFunctionality::Disabled:
                     state = TO_F(RF_DISABLED);
                     break;
                 default:
@@ -366,9 +366,9 @@ void network() {
             SIM808PhoneFunctionality fun;
 
             readNext();
-            if(BUFFER_IS_P(MINIMUM)) fun = SIM808PhoneFunctionality::MINIMUM;
-            else if(BUFFER_IS_P(FULL)) fun = SIM808PhoneFunctionality::FULL;
-            else if(BUFFER_IS_P(RF_DISABLED)) fun = SIM808PhoneFunctionality::RF_DISABLED;
+            if(BUFFER_IS_P(MINIMUM)) fun = SIM808PhoneFunctionality::Minimum;
+            else if(BUFFER_IS_P(FULL)) fun = SIM808PhoneFunctionality::Full;
+            else if(BUFFER_IS_P(RF_DISABLED)) fun = SIM808PhoneFunctionality::Disabled;
             else {
                 unrecognized();
                 return;
@@ -401,19 +401,19 @@ void gps() {
         __FlashStringHelper * state;
 
         switch(status) {
-            case SIM808GpsStatus::FAIL:
+            case SIM808GpsStatus::Fail:
                 state = TO_F(FAILED);
                 break;
-            case SIM808GpsStatus::OFF:
+            case SIM808GpsStatus::Off:
                 state = TO_F(OFF);
                 break;
-            case SIM808GpsStatus::NO_FIX:
+            case SIM808GpsStatus::NoFix:
                 state = S_F("NO_FIX");
                 break;
-            case SIM808GpsStatus::FIX:
+            case SIM808GpsStatus::Fix:
                 state = S_F("FIX");
                 break;
-            case SIM808GpsStatus::ACCURATE_FIX:
+            case SIM808GpsStatus::AccurateFix:
                 state = S_F("ACCURATE_FIX");
                 break;
             default:
@@ -426,49 +426,49 @@ void gps() {
         readNext();
         if(BUFFER_IS_P(ALL) || BUFFER_IS("TIME")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808GpsField::UTC, &timeStr);
+            sim808.getGpsField(position, SIM808GpsField::Utc, &timeStr);
             Log.notice(S_F("time\t\t\t: %s" NL), timeStr);
         }
         
         if(BUFFER_IS_P(ALL) || BUFFER_IS("LAT")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808GpsField::LATITUDE, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::Latitude, &tmpFloat);
             Log.notice(S_F("latitude\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("LON")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808GpsField::LONGITUDE, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::Longitude, &tmpFloat);
             Log.notice(S_F("longitude\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("ALT")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808GpsField::ALTITUDE, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::Altitude, &tmpFloat);
             Log.notice(S_F("altitude\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("SPEED")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808GpsField::SPEED, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::Speed, &tmpFloat);
             Log.notice(S_F("speed\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("COURSE")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808GpsField::COURSE, &tmpFloat);
+            sim808.getGpsField(position, SIM808GpsField::Course, &tmpFloat);
             Log.notice(S_F("course\t\t: %F" NL), tmpFloat);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("SATVIEW")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808GpsField::GPS_IN_VIEW, &tmpInt);
+            sim808.getGpsField(position, SIM808GpsField::GpsInView, &tmpInt);
             Log.notice(S_F("satellites in view\t: %d" NL), tmpInt);
         }
 
         if(BUFFER_IS_P(ALL) || BUFFER_IS("SATUSED")) {
             oneField = true;
-            sim808.getGpsField(position, SIM808GpsField::GNSS_USED, &tmpInt);
+            sim808.getGpsField(position, SIM808GpsField::GnssUsed, &tmpInt);
             Log.notice(S_F("satellites used\t: %d" NL), tmpInt);
         }
 

--- a/examples/Tester/Tester.ino
+++ b/examples/Tester/Tester.ino
@@ -34,32 +34,33 @@
     #define PRINT_LN(s) Serial.println(s)
 #endif
 
+namespace strings {
+    const char UNRECOGNIZED[] S_PROGMEM = "Unrecognized : %s" NL;
+    const char UNKNOWN[] S_PROGMEM = "Unknown value";
 
-const char UNRECOGNIZED[] S_PROGMEM = "Unrecognized : %s" NL;
-const char UNKNOWN[] S_PROGMEM = "Unknown value";
+    const char YES[] S_PROGMEM = "Yes";
+    const char NO[] S_PROGMEM = "No";
 
-const char YES[] S_PROGMEM = "Yes";
-const char NO[] S_PROGMEM = "No";
+    const char SUCCESS[] S_PROGMEM = "Success";
+    const char FAILED[] S_PROGMEM = "Failed";
+    const char ERROR[] S_PROGMEM = "Error";
 
-const char SUCCESS[] S_PROGMEM = "Success";
-const char FAILED[] S_PROGMEM = "Failed";
-const char ERROR[] S_PROGMEM = "Error";
+    const char ON[] S_PROGMEM = "On";
+    const char OFF[] S_PROGMEM = "Off";
+    const char STATUS[] S_PROGMEM = "Status";
+    const char ALL[] S_PROGMEM = "All";
 
-const char ON[] S_PROGMEM = "On";
-const char OFF[] S_PROGMEM = "Off";
-const char STATUS[] S_PROGMEM = "Status";
-const char ALL[] S_PROGMEM = "All";
+    const char MAIN[] S_PROGMEM = "Main";
+    const char GPS[] S_PROGMEM = "Gps";
+    const char NETWORK[] S_PROGMEM = "Network";
 
-const char MAIN[] S_PROGMEM = "Main";
-const char GPS[] S_PROGMEM = "Gps";
-const char NETWORK[] S_PROGMEM = "Network";
+    const char MINIMUM[] S_PROGMEM = "Minimum";
+    const char FULL[] S_PROGMEM = "Full";
+    const char RF_DISABLED[] S_PROGMEM = "Disabled";
 
-const char MINIMUM[] S_PROGMEM = "Minimum";
-const char FULL[] S_PROGMEM = "Full";
-const char RF_DISABLED[] S_PROGMEM = "Disabled";
-
-const char SEND[] S_PROGMEM = "Send";
-const char DEFAULT_URL[] S_PROGMEM = "http://httpbin.org/anything";
+    const char SEND[] S_PROGMEM = "Send";
+    const char DEFAULT_URL[] S_PROGMEM = "http://httpbin.org/anything";
+};
 
 SoftwareSerial simSerial = SoftwareSerial(SIM_TX, SIM_RX);
 SIM808 sim808 = SIM808(SIM_RST, SIM_PWR, SIM_STATUS);
@@ -158,33 +159,33 @@ void init_() {
 void power() {
     readNext();
 
-    if(BUFFER_IS_P(STATUS)) {
+    if(BUFFER_IS_P(strings::STATUS)) {
         bool status;
         __FlashStringHelper * statusText;
         readNext();
         
-        if(BUFFER_IS_P(MAIN)) status = sim808.powered();
-        else if (BUFFER_IS_P(GPS)) sim808.getGpsPowerState(&status);
-        else if (BUFFER_IS_P(NETWORK)) sim808.getGprsPowerState(&status);
+        if(BUFFER_IS_P(strings::MAIN)) status = sim808.powered();
+        else if (BUFFER_IS_P(strings::GPS)) sim808.getGpsPowerState(&status);
+        else if (BUFFER_IS_P(strings::NETWORK)) sim808.getGprsPowerState(&status);
         else {
             unrecognized();
             return;
         }
 
-        Log.notice(S_F("%s : %S" NL), buffer, status ? TO_F(ON) : TO_F(OFF));
+        Log.notice(S_F("%s : %S" NL), buffer, status ? TO_F(strings::ON) : TO_F(strings::OFF));
     }
-    else if(BUFFER_IS_P(ON)) {
+    else if(BUFFER_IS_P(strings::ON)) {
         readNext();
 
-        if(BUFFER_IS_P(MAIN)) {
+        if(BUFFER_IS_P(strings::MAIN)) {
             bool poweredOn = sim808.powerOnOff(true);
-            Log.notice(S_F("powered on %S : %S" NL), TO_F(MAIN), poweredOn ? TO_F(YES) : TO_F(NO));
+            Log.notice(S_F("powered on %S : %S" NL), TO_F(strings::MAIN), poweredOn ? TO_F(strings::YES) : TO_F(strings::NO));
         } 
-        else if(BUFFER_IS_P(GPS)) {
+        else if(BUFFER_IS_P(strings::GPS)) {
             bool poweredOn = sim808.powerOnOffGps(true);
-            Log.notice(S_F("powered on %S : %S" NL), TO_F(GPS), poweredOn ? TO_F(YES) : TO_F(NO));
+            Log.notice(S_F("powered on %S : %S" NL), TO_F(strings::GPS), poweredOn ? TO_F(strings::YES) : TO_F(strings::NO));
         }
-        else if(BUFFER_IS_P(NETWORK)) {
+        else if(BUFFER_IS_P(strings::NETWORK)) {
             char apn[15], user[15], pass[15];
             char *userP = NULL, *passP = NULL;
             
@@ -205,26 +206,26 @@ void power() {
             }
 
             bool success = sim808.enableGprs(apn, userP, passP);
-            Log.notice(S_F("enable GPRS : %S" NL), success ? TO_F(SUCCESS) : TO_F(FAILED));
+            Log.notice(S_F("enable GPRS : %S" NL), success ? TO_F(strings::SUCCESS) : TO_F(strings::FAILED));
         }
         else {
             unrecognized();
             return;
         }
     }
-    else if(BUFFER_IS_P(OFF)) {
+    else if(BUFFER_IS_P(strings::OFF)) {
         readNext();
 
-        if(BUFFER_IS_P(MAIN)) {
+        if(BUFFER_IS_P(strings::MAIN)) {
             bool poweredOff = sim808.powerOnOff(false);
-            Log.notice(S_F("powered off %S : %S" NL), TO_F(MAIN), poweredOff ? TO_F(YES) : TO_F(NO));
+            Log.notice(S_F("powered off %S : %S" NL), TO_F(strings::MAIN), poweredOff ? TO_F(strings::YES) : TO_F(strings::NO));
         }
-        else if(BUFFER_IS_P(GPS)) {
+        else if(BUFFER_IS_P(strings::GPS)) {
             bool poweredOff = sim808.powerOnOffGps(false);
-            Log.notice(S_F("powered off %S : %S" NL), TO_F(GPS), poweredOff ? TO_F(YES) : TO_F(NO));
+            Log.notice(S_F("powered off %S : %S" NL), TO_F(strings::GPS), poweredOff ? TO_F(strings::YES) : TO_F(strings::NO));
 
         }
-        else if(BUFFER_IS_P(NETWORK)) sim808.disableGprs();
+        else if(BUFFER_IS_P(strings::NETWORK)) sim808.disableGprs();
         else {
             unrecognized();
             return;
@@ -242,7 +243,7 @@ void charge() {
 
     switch(status.state) {
         case SIM808ChargingState::Error:
-            state = TO_F(ERROR);
+            state = TO_F(strings::ERROR);
             break;
         case SIM808ChargingState::NotCharging:
             state = S_F("NotCharging");
@@ -254,7 +255,7 @@ void charge() {
             state = S_F("ChargingDone");
             break;
         default:
-            state = TO_F(UNKNOWN);
+            state = TO_F(strings::UNKNOWN);
             break;
     }
 
@@ -267,7 +268,7 @@ void charge() {
 void sim() {
     readNext();
 
-    if(BUFFER_IS_P(STATUS)) {
+    if(BUFFER_IS_P(strings::STATUS)) {
         sim808.getSimState(buffer, BUFFER_SIZE);
         Log.notice(S_F("SIM status : \"%s\"" NL), buffer);
     }
@@ -281,7 +282,7 @@ void sim() {
         }
 
         bool success = sim808.simUnlock(buffer);
-        Log.notice(S_F("SIM unlock : %S" NL), success ? TO_F(SUCCESS) : TO_F(FAILED));
+        Log.notice(S_F("SIM unlock : %S" NL), success ? TO_F(strings::SUCCESS) : TO_F(strings::FAILED));
     }
     else {
         unrecognized();
@@ -298,12 +299,12 @@ void network() {
     bool last = readNext();
     __FlashStringHelper * state;
 
-    if(BUFFER_IS_P(STATUS)) {
+    if(BUFFER_IS_P(strings::STATUS)) {
         SIM808NetworkRegistrationState status = sim808.getNetworkRegistrationStatus();
 
         switch(status) {
             case SIM808NetworkRegistrationState::Error:
-                state = TO_F(ERROR);
+                state = TO_F(strings::ERROR);
                 break;
             case SIM808NetworkRegistrationState::NotSearching:
                 state = S_F("NotSearching");
@@ -324,7 +325,7 @@ void network() {
                 state = S_F("Roaming");
                 break;
             default:
-                state = TO_F(UNKNOWN);
+                state = TO_F(strings::UNKNOWN);
                 break;
         }
 
@@ -344,19 +345,19 @@ void network() {
             SIM808PhoneFunctionality fun = sim808.getPhoneFunctionality();
             switch(fun) {
                 case SIM808PhoneFunctionality::Fail:
-                    state = TO_F(FAILED);
+                    state = TO_F(strings::FAILED);
                     break;
                 case SIM808PhoneFunctionality::Minimum:
-                    state = TO_F(MINIMUM);
+                    state = TO_F(strings::MINIMUM);
                     break;
                 case SIM808PhoneFunctionality::Full:
-                    state = TO_F(FULL);
+                    state = TO_F(strings::FULL);
                     break;
                 case SIM808PhoneFunctionality::Disabled:
-                    state = TO_F(RF_DISABLED);
+                    state = TO_F(strings::RF_DISABLED);
                     break;
                 default:
-                    state = TO_F(UNKNOWN);
+                    state = TO_F(strings::UNKNOWN);
                     break;
             }
 
@@ -366,16 +367,16 @@ void network() {
             SIM808PhoneFunctionality fun;
 
             readNext();
-            if(BUFFER_IS_P(MINIMUM)) fun = SIM808PhoneFunctionality::Minimum;
-            else if(BUFFER_IS_P(FULL)) fun = SIM808PhoneFunctionality::Full;
-            else if(BUFFER_IS_P(RF_DISABLED)) fun = SIM808PhoneFunctionality::Disabled;
+            if(BUFFER_IS_P(strings::MINIMUM)) fun = SIM808PhoneFunctionality::Minimum;
+            else if(BUFFER_IS_P(strings::FULL)) fun = SIM808PhoneFunctionality::Full;
+            else if(BUFFER_IS_P(strings::RF_DISABLED)) fun = SIM808PhoneFunctionality::Disabled;
             else {
                 unrecognized();
                 return;
             }
 
             bool success = sim808.setPhoneFunctionality(fun);
-            Log.notice(S_F("phone functionality : %S" NL), success ? TO_F(SUCCESS) : TO_F(FAILED));            
+            Log.notice(S_F("phone functionality : %S" NL), success ? TO_F(strings::SUCCESS) : TO_F(strings::FAILED));            
         }
     }
 }
@@ -402,10 +403,10 @@ void gps() {
 
         switch(status) {
             case SIM808GpsStatus::Fail:
-                state = TO_F(FAILED);
+                state = TO_F(strings::FAILED);
                 break;
             case SIM808GpsStatus::Off:
-                state = TO_F(OFF);
+                state = TO_F(strings::OFF);
                 break;
             case SIM808GpsStatus::NoFix:
                 state = S_F("NoFix");
@@ -417,56 +418,56 @@ void gps() {
                 state = S_F("AccurateFix");
                 break;
             default:
-                state = TO_F(UNKNOWN);
+                state = TO_F(strings::UNKNOWN);
                 break;
         }
 
         Log.notice(S_F("status\t\t: %S" NL), state);
 
         readNext();
-        if(BUFFER_IS_P(ALL) || BUFFER_IS("TIME")) {
+        if(BUFFER_IS_P(strings::ALL) || BUFFER_IS("TIME")) {
             oneField = true;
             sim808.getGpsField(position, SIM808GpsField::Utc, &timeStr);
             Log.notice(S_F("time\t\t\t: %s" NL), timeStr);
         }
         
-        if(BUFFER_IS_P(ALL) || BUFFER_IS("LAT")) {
+        if(BUFFER_IS_P(strings::ALL) || BUFFER_IS("LAT")) {
             oneField = true;
             sim808.getGpsField(position, SIM808GpsField::Latitude, &tmpFloat);
             Log.notice(S_F("latitude\t\t: %F" NL), tmpFloat);
         }
 
-        if(BUFFER_IS_P(ALL) || BUFFER_IS("LON")) {
+        if(BUFFER_IS_P(strings::ALL) || BUFFER_IS("LON")) {
             oneField = true;
             sim808.getGpsField(position, SIM808GpsField::Longitude, &tmpFloat);
             Log.notice(S_F("longitude\t\t: %F" NL), tmpFloat);
         }
 
-        if(BUFFER_IS_P(ALL) || BUFFER_IS("ALT")) {
+        if(BUFFER_IS_P(strings::ALL) || BUFFER_IS("ALT")) {
             oneField = true;
             sim808.getGpsField(position, SIM808GpsField::Altitude, &tmpFloat);
             Log.notice(S_F("altitude\t\t: %F" NL), tmpFloat);
         }
 
-        if(BUFFER_IS_P(ALL) || BUFFER_IS("SPEED")) {
+        if(BUFFER_IS_P(strings::ALL) || BUFFER_IS("SPEED")) {
             oneField = true;
             sim808.getGpsField(position, SIM808GpsField::Speed, &tmpFloat);
             Log.notice(S_F("speed\t\t: %F" NL), tmpFloat);
         }
 
-        if(BUFFER_IS_P(ALL) || BUFFER_IS("COURSE")) {
+        if(BUFFER_IS_P(strings::ALL) || BUFFER_IS("COURSE")) {
             oneField = true;
             sim808.getGpsField(position, SIM808GpsField::Course, &tmpFloat);
             Log.notice(S_F("course\t\t: %F" NL), tmpFloat);
         }
 
-        if(BUFFER_IS_P(ALL) || BUFFER_IS("SATVIEW")) {
+        if(BUFFER_IS_P(strings::ALL) || BUFFER_IS("SATVIEW")) {
             oneField = true;
             sim808.getGpsField(position, SIM808GpsField::GpsInView, &tmpInt);
             Log.notice(S_F("satellites in view\t: %d" NL), tmpInt);
         }
 
-        if(BUFFER_IS_P(ALL) || BUFFER_IS("SATUSED")) {
+        if(BUFFER_IS_P(strings::ALL) || BUFFER_IS("SATUSED")) {
             oneField = true;
             sim808.getGpsField(position, SIM808GpsField::GnssUsed, &tmpInt);
             Log.notice(S_F("satellites used\t: %d" NL), tmpInt);
@@ -526,7 +527,7 @@ void send() {
         PRINT("[message] ?");
         readNext(true); //read the whole line into buffer
         bool success = sim808.sendSms(number, buffer);
-        Log.notice(S_F("send SMS : %S" NL), success ? TO_F(SUCCESS) : TO_F(FAILED));
+        Log.notice(S_F("send SMS : %S" NL), success ? TO_F(strings::SUCCESS) : TO_F(strings::FAILED));
     }
     else if(BUFFER_IS("HTTP")) return sendHttp();
     else if(BUFFER_IS("AT")) {
@@ -568,8 +569,8 @@ void loop() {
     else if(BUFFER_IS("sim")) sim();
     else if(BUFFER_IS("imei")) imei();
     else if(BUFFER_IS("send")) send();
-    else if(BUFFER_IS_P(NETWORK)) network();
-    else if(BUFFER_IS_P(GPS)) gps();
+    else if(BUFFER_IS_P(strings::NETWORK)) network();
+    else if(BUFFER_IS_P(strings::GPS)) gps();
     else {
         unrecognized();
         return;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SIM808
-version=1.1.0
+version=2.0.0
 author=Bertrand Lemasle
 maintainer=Bertrand Lemasle
 sentence=Straightforward Arduino library for the SIM808

--- a/src/SIM808.Gprs.cpp
+++ b/src/SIM808.Gprs.cpp
@@ -68,9 +68,9 @@ SIM808NetworkRegistrationState SIM808::getNetworkRegistrationStatus()
 	sendAT(TO_F(TOKEN_CGREG), TO_F(TOKEN_READ));
 	
 	if(waitResponse(TO_F(TOKEN_CGREG)) != 0 ||
-		!parseReply(',', (uint8_t)SIM808RegistrationStatusResponse::STAT, &stat) ||
+		!parseReply(',', (uint8_t)SIM808RegistrationStatusResponse::Stat, &stat) ||
 		waitResponse() != 0)
-		return SIM808NetworkRegistrationState::ERROR;
+		return SIM808NetworkRegistrationState::Error;
 
 	return (SIM808NetworkRegistrationState)stat;
 }

--- a/src/SIM808.Gprs.cpp
+++ b/src/SIM808.Gprs.cpp
@@ -62,15 +62,15 @@ bool SIM808::disableGprs()
 		(sendFormatAT(TO_F(AT_COMMAND_GPRS_ATTACH), 0), waitResponse(10000L) == 0);							//AT+CGATT=0
 }
 
-SIM808_NETWORK_REGISTRATION_STATE SIM808::getNetworkRegistrationStatus()
+SIM808NetworkRegistrationState SIM808::getNetworkRegistrationStatus()
 {
 	uint8_t stat;
 	sendAT(TO_F(TOKEN_CGREG), TO_F(TOKEN_READ));
 	
 	if(waitResponse(TO_F(TOKEN_CGREG)) != 0 ||
-		!parseReply(',', (uint8_t)SIM808_REGISTRATION_STATUS_RESPONSE::STAT, &stat) ||
+		!parseReply(',', (uint8_t)SIM808RegistrationStatusResponse::STAT, &stat) ||
 		waitResponse() != 0)
-		return SIM808_NETWORK_REGISTRATION_STATE::ERROR;
+		return SIM808NetworkRegistrationState::ERROR;
 
-	return (SIM808_NETWORK_REGISTRATION_STATE)stat;
+	return (SIM808NetworkRegistrationState)stat;
 }

--- a/src/SIM808.Gprs.cpp
+++ b/src/SIM808.Gprs.cpp
@@ -36,7 +36,7 @@ bool SIM808::getGprsPowerState(bool *state)
 	return true;
 }
 
-bool SIM808::enableGprs(const char *apn, const char* user = NULL, const char *password = NULL)
+bool SIM808::enableGprs(const char *apn, const char* user, const char *password)
 {
 	char gprsToken[5];
 	strcpy_P(gprsToken, TOKEN_GPRS);

--- a/src/SIM808.Gps.cpp
+++ b/src/SIM808.Gps.cpp
@@ -63,7 +63,7 @@ SIM808_GPS_STATUS SIM808::getGpsStatus(char * response, size_t responseSize, uin
 	if(replyBuffer[shift] == '0') result = SIM808_GPS_STATUS::OFF;
 	if(replyBuffer[shift + 2] == '1') // fix acquired
 	{
-		int16_t satellitesUsed;
+		uint16_t satellitesUsed;
 		getGpsField(replyBuffer, SIM808_GPS_FIELD::GNSS_USED, &satellitesUsed);
 
 		result = satellitesUsed > minSatellitesForAccurateFix ?

--- a/src/SIM808.Gps.cpp
+++ b/src/SIM808.Gps.cpp
@@ -49,7 +49,7 @@ bool SIM808::getGpsField(const char* response, SIM808_GPS_FIELD field, float* re
 	return true;
 }
 
-SIM808_GPS_STATUS SIM808::getGpsStatus(char * response, size_t responseSize, uint8_t minSatellitesForAccurateFix = GPS_ACCURATE_FIX_MIN_SATELLITES)
+SIM808_GPS_STATUS SIM808::getGpsStatus(char * response, size_t responseSize, uint8_t minSatellitesForAccurateFix)
 {	
 	SIM808_GPS_STATUS result = SIM808_GPS_STATUS::NO_FIX;
 

--- a/src/SIM808.Gps.cpp
+++ b/src/SIM808.Gps.cpp
@@ -31,7 +31,7 @@ void SIM808::getGpsField(const char* response, SIM808GpsField field, char** resu
 
 bool SIM808::getGpsField(const char* response, SIM808GpsField field, uint16_t* result)
 {
-	if (field < SIM808GpsField::SPEED) return false;
+	if (field < SIM808GpsField::Speed) return false;
 
 	parse(response, ',', (uint8_t)field, result);
 	return true;
@@ -39,11 +39,11 @@ bool SIM808::getGpsField(const char* response, SIM808GpsField field, uint16_t* r
 
 bool SIM808::getGpsField(const char* response, SIM808GpsField field, float* result)
 {
-	if (field != SIM808GpsField::COURSE && 
-		field != SIM808GpsField::LATITUDE &&
-		field != SIM808GpsField::LONGITUDE &&
-		field != SIM808GpsField::ALTITUDE &&
-		field != SIM808GpsField::SPEED) return false;
+	if (field != SIM808GpsField::Course && 
+		field != SIM808GpsField::Latitude &&
+		field != SIM808GpsField::Longitude &&
+		field != SIM808GpsField::Altitude &&
+		field != SIM808GpsField::Speed) return false;
 
 	parse(response, ',', (uint8_t)field, result);
 	return true;
@@ -51,29 +51,29 @@ bool SIM808::getGpsField(const char* response, SIM808GpsField field, float* resu
 
 SIM808GpsStatus SIM808::getGpsStatus(char * response, size_t responseSize, uint8_t minSatellitesForAccurateFix)
 {	
-	SIM808GpsStatus result = SIM808GpsStatus::NO_FIX;
+	SIM808GpsStatus result = SIM808GpsStatus::NoFix;
 
 	sendAT(TO_F(TOKEN_GPS_INFO));
 
 	if(waitResponse(TO_F(TOKEN_GPS_INFO)) != 0)
-		return SIM808GpsStatus::FAIL;
+		return SIM808GpsStatus::Fail;
 
 	uint16_t shift = strlen_P(TOKEN_GPS_INFO) + 2;
 
-	if(replyBuffer[shift] == '0') result = SIM808GpsStatus::OFF;
+	if(replyBuffer[shift] == '0') result = SIM808GpsStatus::Off;
 	if(replyBuffer[shift + 2] == '1') // fix acquired
 	{
 		uint16_t satellitesUsed;
-		getGpsField(replyBuffer, SIM808GpsField::GNSS_USED, &satellitesUsed);
+		getGpsField(replyBuffer, SIM808GpsField::GnssUsed, &satellitesUsed);
 
 		result = satellitesUsed > minSatellitesForAccurateFix ?
-			SIM808GpsStatus::ACCURATE_FIX :
-			SIM808GpsStatus::FIX;
+			SIM808GpsStatus::AccurateFix :
+			SIM808GpsStatus::Fix;
 
 		copyCurrentLine(response, responseSize, shift);
 	}
 
-	if(waitResponse() != 0) return SIM808GpsStatus::FAIL;
+	if(waitResponse() != 0) return SIM808GpsStatus::Fail;
 
 	return result;
 }

--- a/src/SIM808.Gps.cpp
+++ b/src/SIM808.Gps.cpp
@@ -23,57 +23,57 @@ bool SIM808::getGpsPosition(char *response, size_t responseSize)
 	copyCurrentLine(response, responseSize, strlen_P(TOKEN_GPS_INFO) + 2);
 }
 
-void SIM808::getGpsField(const char* response, SIM808_GPS_FIELD field, char** result) 
+void SIM808::getGpsField(const char* response, SIM808GpsField field, char** result) 
 {
 	char *pTmp = find(response, ',', (uint8_t)field);
 	*result = pTmp;
 }
 
-bool SIM808::getGpsField(const char* response, SIM808_GPS_FIELD field, uint16_t* result)
+bool SIM808::getGpsField(const char* response, SIM808GpsField field, uint16_t* result)
 {
-	if (field < SIM808_GPS_FIELD::SPEED) return false;
+	if (field < SIM808GpsField::SPEED) return false;
 
 	parse(response, ',', (uint8_t)field, result);
 	return true;
 }
 
-bool SIM808::getGpsField(const char* response, SIM808_GPS_FIELD field, float* result)
+bool SIM808::getGpsField(const char* response, SIM808GpsField field, float* result)
 {
-	if (field != SIM808_GPS_FIELD::COURSE && 
-		field != SIM808_GPS_FIELD::LATITUDE &&
-		field != SIM808_GPS_FIELD::LONGITUDE &&
-		field != SIM808_GPS_FIELD::ALTITUDE &&
-		field != SIM808_GPS_FIELD::SPEED) return false;
+	if (field != SIM808GpsField::COURSE && 
+		field != SIM808GpsField::LATITUDE &&
+		field != SIM808GpsField::LONGITUDE &&
+		field != SIM808GpsField::ALTITUDE &&
+		field != SIM808GpsField::SPEED) return false;
 
 	parse(response, ',', (uint8_t)field, result);
 	return true;
 }
 
-SIM808_GPS_STATUS SIM808::getGpsStatus(char * response, size_t responseSize, uint8_t minSatellitesForAccurateFix)
+SIM808GpsStatus SIM808::getGpsStatus(char * response, size_t responseSize, uint8_t minSatellitesForAccurateFix)
 {	
-	SIM808_GPS_STATUS result = SIM808_GPS_STATUS::NO_FIX;
+	SIM808GpsStatus result = SIM808GpsStatus::NO_FIX;
 
 	sendAT(TO_F(TOKEN_GPS_INFO));
 
 	if(waitResponse(TO_F(TOKEN_GPS_INFO)) != 0)
-		return SIM808_GPS_STATUS::FAIL;
+		return SIM808GpsStatus::FAIL;
 
 	uint16_t shift = strlen_P(TOKEN_GPS_INFO) + 2;
 
-	if(replyBuffer[shift] == '0') result = SIM808_GPS_STATUS::OFF;
+	if(replyBuffer[shift] == '0') result = SIM808GpsStatus::OFF;
 	if(replyBuffer[shift + 2] == '1') // fix acquired
 	{
 		uint16_t satellitesUsed;
-		getGpsField(replyBuffer, SIM808_GPS_FIELD::GNSS_USED, &satellitesUsed);
+		getGpsField(replyBuffer, SIM808GpsField::GNSS_USED, &satellitesUsed);
 
 		result = satellitesUsed > minSatellitesForAccurateFix ?
-			SIM808_GPS_STATUS::ACCURATE_FIX :
-			SIM808_GPS_STATUS::FIX;
+			SIM808GpsStatus::ACCURATE_FIX :
+			SIM808GpsStatus::FIX;
 
 		copyCurrentLine(response, responseSize, shift);
 	}
 
-	if(waitResponse() != 0) return SIM808_GPS_STATUS::FAIL;
+	if(waitResponse() != 0) return SIM808GpsStatus::FAIL;
 
 	return result;
 }

--- a/src/SIM808.Gsm.cpp
+++ b/src/SIM808.Gsm.cpp
@@ -51,8 +51,8 @@ SIM808SignalQualityReport SIM808::getSignalQuality()
 
 	sendAT(TO_F(TOKEN_CSQ));
 	if(waitResponse(TO_F(TOKEN_CSQ)) != 0 ||
-		!parseReply(',', (uint8_t)SIM808_SIGNAL_QUALITY_RESPONSE::SIGNAL_STRENGTH, &quality) ||
-		!parseReply(',', (uint8_t)SIM808_SIGNAL_QUALITY_RESPONSE::BIT_ERROR_RATE, &errorRate) ||
+		!parseReply(',', (uint8_t)SIM808SignalQualityResponse::SIGNAL_STRENGTH, &quality) ||
+		!parseReply(',', (uint8_t)SIM808SignalQualityResponse::BIT_ERROR_RATE, &errorRate) ||
 		waitResponse())
 		return report;
 
@@ -68,7 +68,7 @@ SIM808SignalQualityReport SIM808::getSignalQuality()
 	return report;
 }
 
-bool SIM808::setSmsMessageFormat(SIM808_SMS_MESSAGE_FORMAT format)
+bool SIM808::setSmsMessageFormat(SIM808SmsMessageFormat format)
 {
 	sendAT(S_F("+CMGF="), (uint8_t)format);
 	return waitResponse() == 0;
@@ -76,7 +76,7 @@ bool SIM808::setSmsMessageFormat(SIM808_SMS_MESSAGE_FORMAT format)
 
 bool SIM808::sendSms(const char *addr, const char *msg)
 {
-	if (!setSmsMessageFormat(SIM808_SMS_MESSAGE_FORMAT::TEXT)) return false;
+	if (!setSmsMessageFormat(SIM808SmsMessageFormat::TEXT)) return false;
 	sendFormatAT(TO_F(AT_COMMAND_SEND_SMS), addr);
 
 	if (!waitResponse(S_F(">")) == 0) return false;

--- a/src/SIM808.Gsm.cpp
+++ b/src/SIM808.Gsm.cpp
@@ -51,8 +51,8 @@ SIM808SignalQualityReport SIM808::getSignalQuality()
 
 	sendAT(TO_F(TOKEN_CSQ));
 	if(waitResponse(TO_F(TOKEN_CSQ)) != 0 ||
-		!parseReply(',', (uint8_t)SIM808SignalQualityResponse::SIGNAL_STRENGTH, &quality) ||
-		!parseReply(',', (uint8_t)SIM808SignalQualityResponse::BIT_ERROR_RATE, &errorRate) ||
+		!parseReply(',', (uint8_t)SIM808SignalQualityResponse::SignalStrength, &quality) ||
+		!parseReply(',', (uint8_t)SIM808SignalQualityResponse::BitErrorrate, &errorRate) ||
 		waitResponse())
 		return report;
 
@@ -76,7 +76,7 @@ bool SIM808::setSmsMessageFormat(SIM808SmsMessageFormat format)
 
 bool SIM808::sendSms(const char *addr, const char *msg)
 {
-	if (!setSmsMessageFormat(SIM808SmsMessageFormat::TEXT)) return false;
+	if (!setSmsMessageFormat(SIM808SmsMessageFormat::Text)) return false;
 	sendFormatAT(TO_F(AT_COMMAND_SEND_SMS), addr);
 
 	if (!waitResponse(S_F(">")) == 0) return false;

--- a/src/SIM808.Http.cpp
+++ b/src/SIM808.Http.cpp
@@ -49,7 +49,7 @@ uint16_t SIM808::httpGet(const char *url, char *response, size_t responseSize)
 	size_t dataSize = 0;
 
 	bool result = setupHttpRequest(url) &&
-		fireHttpRequest(SIM808_HTTP_ACTION::GET, &statusCode, &dataSize) &&
+		fireHttpRequest(SIM808HttpAction::GET, &statusCode, &dataSize) &&
 		readHttpResponse(response, responseSize, dataSize) &&
 		httpEnd();
 
@@ -64,7 +64,7 @@ uint16_t SIM808::httpPost(const char *url, ATConstStr contentType, const char *b
 	bool result = setupHttpRequest(url) &&
 		setHttpParameter(TO_F(AT_COMMAND_PARAMETER_HTTP_CONTENT), contentType) &&
 		setHttpBody(body) &&
-		fireHttpRequest(SIM808_HTTP_ACTION::POST, &statusCode, &dataSize) &&
+		fireHttpRequest(SIM808HttpAction::POST, &statusCode, &dataSize) &&
 		readHttpResponse(response, responseSize, dataSize) &&
 		httpEnd();
 
@@ -106,13 +106,13 @@ bool SIM808::setHttpBody(const char* body)
 	return true;
 }
 
-bool SIM808::fireHttpRequest(const SIM808_HTTP_ACTION action, uint16_t *statusCode, size_t *dataSize)
+bool SIM808::fireHttpRequest(const SIM808HttpAction action, uint16_t *statusCode, size_t *dataSize)
 {
 	sendAT(TO_F(TOKEN_HTTP_ACTION), TO_F(TOKEN_WRITE), (uint8_t)action);
 
 	return waitResponse(HTTP_TIMEOUT, TO_F(TOKEN_HTTP_ACTION)) == 0 &&
-		parseReply(',', (uint8_t)SIM808_HTTP_ACTION_RESPONSE::STATUS_CODE, statusCode) &&
-		parseReply(',', (uint8_t)SIM808_HTTP_ACTION_RESPONSE::DATA_LEN, dataSize);
+		parseReply(',', (uint8_t)SIM808HttpActionResponse::STATUS_CODE, statusCode) &&
+		parseReply(',', (uint8_t)SIM808HttpActionResponse::DATA_LEN, dataSize);
 }
 
 bool SIM808::readHttpResponse(char *response, size_t responseSize, size_t dataSize)

--- a/src/SIM808.Http.cpp
+++ b/src/SIM808.Http.cpp
@@ -49,7 +49,7 @@ uint16_t SIM808::httpGet(const char *url, char *response, size_t responseSize)
 	size_t dataSize = 0;
 
 	bool result = setupHttpRequest(url) &&
-		fireHttpRequest(SIM808HttpAction::GET, &statusCode, &dataSize) &&
+		fireHttpRequest(SIM808HttpAction::Get, &statusCode, &dataSize) &&
 		readHttpResponse(response, responseSize, dataSize) &&
 		httpEnd();
 
@@ -64,7 +64,7 @@ uint16_t SIM808::httpPost(const char *url, ATConstStr contentType, const char *b
 	bool result = setupHttpRequest(url) &&
 		setHttpParameter(TO_F(AT_COMMAND_PARAMETER_HTTP_CONTENT), contentType) &&
 		setHttpBody(body) &&
-		fireHttpRequest(SIM808HttpAction::POST, &statusCode, &dataSize) &&
+		fireHttpRequest(SIM808HttpAction::Post, &statusCode, &dataSize) &&
 		readHttpResponse(response, responseSize, dataSize) &&
 		httpEnd();
 
@@ -111,8 +111,8 @@ bool SIM808::fireHttpRequest(const SIM808HttpAction action, uint16_t *statusCode
 	sendAT(TO_F(TOKEN_HTTP_ACTION), TO_F(TOKEN_WRITE), (uint8_t)action);
 
 	return waitResponse(HTTP_TIMEOUT, TO_F(TOKEN_HTTP_ACTION)) == 0 &&
-		parseReply(',', (uint8_t)SIM808HttpActionResponse::STATUS_CODE, statusCode) &&
-		parseReply(',', (uint8_t)SIM808HttpActionResponse::DATA_LEN, dataSize);
+		parseReply(',', (uint8_t)SIM808HttpActionResponse::StatusCode, statusCode) &&
+		parseReply(',', (uint8_t)SIM808HttpActionResponse::DataLen, dataSize);
 }
 
 bool SIM808::readHttpResponse(char *response, size_t responseSize, size_t dataSize)

--- a/src/SIM808.Http.cpp
+++ b/src/SIM808.Http.cpp
@@ -27,11 +27,15 @@ bool SIM808::setHttpParameter(ATConstStr parameter, ATConstStr value)
 	return waitResponse() == 0;
 }
 
+#if defined(__AVR__)
+
 bool SIM808::setHttpParameter(ATConstStr parameter, const char * value)
 {
 	sendFormatAT(TO_F(AT_COMMAND_SET_HTTP_PARAMETER_STRING), parameter, value);
 	return waitResponse() == 0;
 }
+
+#endif
 
 bool SIM808::setHttpParameter(ATConstStr parameter, uint8_t value)
 {

--- a/src/SIM808.Power.cpp
+++ b/src/SIM808.Power.cpp
@@ -45,16 +45,16 @@ SIM808ChargingStatus SIM808::getChargingState()
 	sendAT(TO_F(TOKEN_CBC));
 
 	if (waitResponse(TO_F(TOKEN_CBC)) == 0 &&
-		parseReply(',', (uint8_t)SIM808_BATTERY_CHARGE_FIELD::BCS, &state) &&
-		parseReply(',', (uint8_t)SIM808_BATTERY_CHARGE_FIELD::BCL, &level) &&
-		parseReply(',', (uint16_t)SIM808_BATTERY_CHARGE_FIELD::VOLTAGE, &voltage) &&
+		parseReply(',', (uint8_t)SIM808BatteryChargeField::BCS, &state) &&
+		parseReply(',', (uint8_t)SIM808BatteryChargeField::BCL, &level) &&
+		parseReply(',', (uint16_t)SIM808BatteryChargeField::VOLTAGE, &voltage) &&
 		waitResponse() == 0)
-		return { (SIM808_CHARGING_STATE)state, level, voltage };
+		return { (SIM808ChargingState)state, level, voltage };
 			
-	return { SIM808_CHARGING_STATE::ERROR, 0, 0 };
+	return { SIM808ChargingState::ERROR, 0, 0 };
 }
 
-SIM808_PHONE_FUNCTIONALITY SIM808::getPhoneFunctionality()
+SIM808PhoneFunctionality SIM808::getPhoneFunctionality()
 {
 	uint8_t state;
 
@@ -63,19 +63,19 @@ SIM808_PHONE_FUNCTIONALITY SIM808::getPhoneFunctionality()
 	if (waitResponse(10000L, TO_F(TOKEN_CFUN)) == 0 &&
 		parseReply(',', 0, &state) &&
 		waitResponse() == 0)
-		return (SIM808_PHONE_FUNCTIONALITY)state;
+		return (SIM808PhoneFunctionality)state;
 	
-	return SIM808_PHONE_FUNCTIONALITY::FAIL;
+	return SIM808PhoneFunctionality::FAIL;
 }
 
-bool SIM808::setPhoneFunctionality(SIM808_PHONE_FUNCTIONALITY fun)
+bool SIM808::setPhoneFunctionality(SIM808PhoneFunctionality fun)
 {
 	sendAT(TO_F(TOKEN_CFUN), TO_F(TOKEN_WRITE), (uint8_t)fun);
 
 	return waitResponse(10000L) == 0;
 }
 
-bool SIM808::setSlowClock(SIM808_SLOW_CLOCK mode)
+bool SIM808::setSlowClock(SIM808SlowClock mode)
 {
 	sendAT(S_F("+CSCLK"), TO_F(TOKEN_WRITE), (uint8_t)mode);
 

--- a/src/SIM808.Power.cpp
+++ b/src/SIM808.Power.cpp
@@ -45,13 +45,13 @@ SIM808ChargingStatus SIM808::getChargingState()
 	sendAT(TO_F(TOKEN_CBC));
 
 	if (waitResponse(TO_F(TOKEN_CBC)) == 0 &&
-		parseReply(',', (uint8_t)SIM808BatteryChargeField::BCS, &state) &&
-		parseReply(',', (uint8_t)SIM808BatteryChargeField::BCL, &level) &&
-		parseReply(',', (uint16_t)SIM808BatteryChargeField::VOLTAGE, &voltage) &&
+		parseReply(',', (uint8_t)SIM808BatteryChargeField::Bcs, &state) &&
+		parseReply(',', (uint8_t)SIM808BatteryChargeField::Bcl, &level) &&
+		parseReply(',', (uint16_t)SIM808BatteryChargeField::Voltage, &voltage) &&
 		waitResponse() == 0)
 		return { (SIM808ChargingState)state, level, voltage };
 			
-	return { SIM808ChargingState::ERROR, 0, 0 };
+	return { SIM808ChargingState::Error, 0, 0 };
 }
 
 SIM808PhoneFunctionality SIM808::getPhoneFunctionality()
@@ -65,7 +65,7 @@ SIM808PhoneFunctionality SIM808::getPhoneFunctionality()
 		waitResponse() == 0)
 		return (SIM808PhoneFunctionality)state;
 	
-	return SIM808PhoneFunctionality::FAIL;
+	return SIM808PhoneFunctionality::Fail;
 }
 
 bool SIM808::setPhoneFunctionality(SIM808PhoneFunctionality fun)

--- a/src/SIM808.Types.h
+++ b/src/SIM808.Types.h
@@ -2,13 +2,13 @@
 
 #include <Arduino.h>
 
-enum class SIM808_ECHO : uint8_t
+enum class SIM808Echo : uint8_t
 {
 	OFF = 0,
 	ON = 1
 };
 
-enum class SIM808_SMS_MESSAGE_FORMAT : uint8_t
+enum class SIM808SmsMessageFormat : uint8_t
 {
 	PDU = 0,
 	TEXT = 1
@@ -17,7 +17,7 @@ enum class SIM808_SMS_MESSAGE_FORMAT : uint8_t
 /**
  * List of supported HTTP methods.
  */
-enum class SIM808_HTTP_ACTION : uint8_t
+enum class SIM808HttpAction : uint8_t
 {
 	GET = 0,
 	POST = 1,
@@ -27,7 +27,7 @@ enum class SIM808_HTTP_ACTION : uint8_t
 /**
  * Fields returned by the AT+HTTPACTION command.
  */
-enum class SIM808_HTTP_ACTION_RESPONSE : uint8_t
+enum class SIM808HttpActionResponse : uint8_t
 {
 	METHOD = 0,			///< HTTP method.
 	STATUS_CODE = 1,	///< Status code responded by the remote server.
@@ -37,10 +37,10 @@ enum class SIM808_HTTP_ACTION_RESPONSE : uint8_t
 /**
  * Fields returned by the AT+CGREG command.
  */
-enum class SIM808_REGISTRATION_STATUS_RESPONSE : uint8_t
+enum class SIM808RegistrationStatusResponse : uint8_t
 {
 	N = 0,		///< Controls network registration unsolicited result code.
-	STAT = 1,	///< Current registration status. See SIM808_NETWORK_REGISTRATION_STATE.
+	STAT = 1,	///< Current registration status. See SIM808NetworkRegistrationState.
 	LAC = 2,	///< Location information.
 	CI = 3		///< Location information.
 };
@@ -48,13 +48,13 @@ enum class SIM808_REGISTRATION_STATUS_RESPONSE : uint8_t
 /**
  * Fields return by the AT+CSQ command.
  */
-enum class SIM808_SIGNAL_QUALITY_RESPONSE : uint8_t
+enum class SIM808SignalQualityResponse : uint8_t
 {
 	SIGNAL_STRENGTH = 0,	///< Received Signal Strength Indication
 	BIT_ERROR_RATE = 1		///< Bit Error Rate
 };
 
-enum class SIM808_PHONE_FUNCTIONALITY : int8_t
+enum class SIM808PhoneFunctionality : int8_t
 {
 	FAIL = -1,		///< Reading the current phone functionality has failed.
 	MINIMUM = 0,	///< Minimum functionality.
@@ -62,7 +62,7 @@ enum class SIM808_PHONE_FUNCTIONALITY : int8_t
 	RF_DISABLED = 4	///< Disable phone both transmit and receive RF circuit.
 };
 
-enum class SIM808_GPS_STATUS : int8_t
+enum class SIM808GpsStatus : int8_t
 {
 	FAIL = -1,			///< Reading the current GPS position has failed.
 	OFF = 0,			///< GPS is off.
@@ -71,7 +71,7 @@ enum class SIM808_GPS_STATUS : int8_t
 	ACCURATE_FIX = 3	///< An accurate fix is acquired, using more than GPS_ACCURATE_FIX_MIN_SATELLITES.
 };
 
-enum class SIM808_GPS_FIELD : uint8_t
+enum class SIM808GpsField : uint8_t
 {
 	UTC = 2,			///< UTC date time, as yyyyMMddhhmmss.000.
 	LATITUDE = 3,		///< Latitude in degrees.
@@ -83,21 +83,21 @@ enum class SIM808_GPS_FIELD : uint8_t
 	GNSS_USED = 15		///< GPS satellites used to acquire the position.
 };
 
-enum class SIM808_BATTERY_CHARGE_FIELD : uint8_t
+enum class SIM808BatteryChargeField : uint8_t
 {
 	BCS = 0,	///< Battery Charge State.
 	BCL = 1,	///< Battery Charge Level.
 	VOLTAGE = 2	///< Battery voltage.
 };
 
-enum class SIM808_SLOW_CLOCK : uint8_t
+enum class SIM808SlowClock : uint8_t
 {
 	DISABLE = 0,	///< Disables slow clock, module will not enter sleep mode
 	ENABLE = 1,		///< Enables slow clock, controlled by DTR pin.
 	AUTO = 2		///< Enables slow clock automatically.
 };
 
-enum class SIM808_CHARGING_STATE : int8_t
+enum class SIM808ChargingState : int8_t
 {
 	ERROR = -1,			///< Reading the current charging status has failed.
 	NOT_CHARGING = 0,	///< Not charging.
@@ -105,7 +105,7 @@ enum class SIM808_CHARGING_STATE : int8_t
 	CHARGING_DONE = 2	///< Plugged in, but charging done.
 };
 
-enum class SIM808_NETWORK_REGISTRATION_STATE : int8_t
+enum class SIM808NetworkRegistrationState : int8_t
 {
 	ERROR = -1,			///< Reading the current network registration status as failed.
 	NOT_SEARCHING = 0,	///< Not searching.
@@ -125,7 +125,7 @@ struct SIM808SignalQualityReport
 
 struct SIM808ChargingStatus
 {
-	SIM808_CHARGING_STATE state;	///< Current charging state.
+	SIM808ChargingState state;	///< Current charging state.
 	int8_t level;					///< Battery level, expressed as a percentage.
 	int16_t voltage;				///< Battery level, expressed in mV.
 };

--- a/src/SIM808.Types.h
+++ b/src/SIM808.Types.h
@@ -4,14 +4,14 @@
 
 enum class SIM808Echo : uint8_t
 {
-	OFF = 0,
-	ON = 1
+	Off = 0,
+	On = 1
 };
 
 enum class SIM808SmsMessageFormat : uint8_t
 {
-	PDU = 0,
-	TEXT = 1
+	Pdu = 0,
+	Text = 1
 };
 
 /**
@@ -19,9 +19,9 @@ enum class SIM808SmsMessageFormat : uint8_t
  */
 enum class SIM808HttpAction : uint8_t
 {
-	GET = 0,
-	POST = 1,
-	HEAD = 2
+	Get = 0,
+	Post = 1,
+	Head = 2
 };
 
 /**
@@ -29,9 +29,9 @@ enum class SIM808HttpAction : uint8_t
  */
 enum class SIM808HttpActionResponse : uint8_t
 {
-	METHOD = 0,			///< HTTP method.
-	STATUS_CODE = 1,	///< Status code responded by the remote server.
-	DATA_LEN = 2		///< Response body length.
+	Method = 0,		///< HTTP method.
+	StatusCode = 1,	///< Status code responded by the remote server.
+	DataLen = 2		///< Response body length.
 };
 
 /**
@@ -40,9 +40,9 @@ enum class SIM808HttpActionResponse : uint8_t
 enum class SIM808RegistrationStatusResponse : uint8_t
 {
 	N = 0,		///< Controls network registration unsolicited result code.
-	STAT = 1,	///< Current registration status. See SIM808NetworkRegistrationState.
-	LAC = 2,	///< Location information.
-	CI = 3		///< Location information.
+	Stat = 1,	///< Current registration status. See SIM808NetworkRegistrationState.
+	Lac = 2,	///< Location information.
+	Ci = 3		///< Location information.
 };
 
 /**
@@ -50,70 +50,70 @@ enum class SIM808RegistrationStatusResponse : uint8_t
  */
 enum class SIM808SignalQualityResponse : uint8_t
 {
-	SIGNAL_STRENGTH = 0,	///< Received Signal Strength Indication
-	BIT_ERROR_RATE = 1		///< Bit Error Rate
+	SignalStrength = 0,	///< Received Signal Strength Indication
+	BitErrorrate = 1	///< Bit Error Rate
 };
 
 enum class SIM808PhoneFunctionality : int8_t
 {
-	FAIL = -1,		///< Reading the current phone functionality has failed.
-	MINIMUM = 0,	///< Minimum functionality.
-	FULL = 1,		///< Full functionality (default on device power on).
-	RF_DISABLED = 4	///< Disable phone both transmit and receive RF circuit.
+	Fail = -1,		///< Reading the current phone functionality has failed.
+	Minimum = 0,	///< Minimum functionality.
+	Full = 1,		///< Full functionality (default on device power on).
+	Disabled = 4	///< Disable phone both transmit and receive RF circuit.
 };
 
 enum class SIM808GpsStatus : int8_t
 {
-	FAIL = -1,			///< Reading the current GPS position has failed.
-	OFF = 0,			///< GPS is off.
-	NO_FIX = 1,			///< A fix is not acquired yet.
-	FIX = 2,			///< A fix is acquired.
-	ACCURATE_FIX = 3	///< An accurate fix is acquired, using more than GPS_ACCURATE_FIX_MIN_SATELLITES.
+	Fail = -1,			///< Reading the current GPS position has failed.
+	Off = 0,			///< GPS is off.
+	NoFix = 1,			///< A fix is not acquired yet.
+	Fix = 2,			///< A fix is acquired.
+	AccurateFix = 3		///< An accurate fix is acquired, using more than GPS_ACCURATE_FIX_MIN_SATELLITES.
 };
 
 enum class SIM808GpsField : uint8_t
 {
-	UTC = 2,			///< UTC date time, as yyyyMMddhhmmss.000.
-	LATITUDE = 3,		///< Latitude in degrees.
-	LONGITUDE = 4,		///< Longitude in degress.
-	ALTITUDE = 5,		///< Altitude in meters.
-	SPEED = 6,			///< Speed over ground in km/h.
-	COURSE = 7,			///< Course over ground in degrees.
-	GPS_IN_VIEW = 14,	///< GPS satellites in view.
-	GNSS_USED = 15		///< GPS satellites used to acquire the position.
+	Utc = 2,			///< UTC date time, as yyyyMMddhhmmss.000.
+	Latitude = 3,		///< Latitude in degrees.
+	Longitude = 4,		///< Longitude in degress.
+	Altitude = 5,		///< Altitude in meters.
+	Speed = 6,			///< Speed over ground in km/h.
+	Course = 7,			///< Course over ground in degrees.
+	GpsInView = 14,		///< GPS satellites in view.
+	GnssUsed = 15		///< GPS satellites used to acquire the position.
 };
 
 enum class SIM808BatteryChargeField : uint8_t
 {
-	BCS = 0,	///< Battery Charge State.
-	BCL = 1,	///< Battery Charge Level.
-	VOLTAGE = 2	///< Battery voltage.
+	Bcs = 0,	///< Battery Charge State.
+	Bcl = 1,	///< Battery Charge Level.
+	Voltage = 2	///< Battery voltage.
 };
 
 enum class SIM808SlowClock : uint8_t
 {
-	DISABLE = 0,	///< Disables slow clock, module will not enter sleep mode
-	ENABLE = 1,		///< Enables slow clock, controlled by DTR pin.
-	AUTO = 2		///< Enables slow clock automatically.
+	Disable = 0,	///< Disables slow clock, module will not enter sleep mode
+	Enable = 1,		///< Enables slow clock, controlled by DTR pin.
+	Auto = 2		///< Enables slow clock automatically.
 };
 
 enum class SIM808ChargingState : int8_t
 {
-	ERROR = -1,			///< Reading the current charging status has failed.
-	NOT_CHARGING = 0,	///< Not charging.
-	CHARGING = 1,		///< Charging.
-	CHARGING_DONE = 2	///< Plugged in, but charging done.
+	Error = -1,			///< Reading the current charging status has failed.
+	NotCharging = 0,	///< Not charging.
+	Charging = 1,		///< Charging.
+	ChargingDone = 2	///< Plugged in, but charging done.
 };
 
 enum class SIM808NetworkRegistrationState : int8_t
 {
-	ERROR = -1,			///< Reading the current network registration status as failed.
-	NOT_SEARCHING = 0,	///< Not searching.
-	REGISTERED = 1,		///< Registered to the home network.
-	SEARCHING  = 2,		///< Not registered but searching for a network to register.
-	DENIED = 3,			///< Registration has been denied by the provider. Stopped searching.
-	UNKNOWN = 4,		///< Unknown
-	ROAMING = 5			///< Registered to a network that is not the home network.
+	Error = -1,			///< Reading the current network registration status as failed.
+	NotSearching = 0,	///< Not searching.
+	Registered = 1,		///< Registered to the home network.
+	Searching  = 2,		///< Not registered but searching for a network to register.
+	Denied = 3,			///< Registration has been denied by the provider. Stopped searching.
+	Unknown = 4,		///< Unknown
+	Roaming = 5			///< Registered to a network that is not the home network.
 };
 
 struct SIM808SignalQualityReport

--- a/src/SIM808.Types.h
+++ b/src/SIM808.Types.h
@@ -59,7 +59,7 @@ enum class SIM808_PHONE_FUNCTIONALITY : int8_t
 	FAIL = -1,		///< Reading the current phone functionality has failed.
 	MINIMUM = 0,	///< Minimum functionality.
 	FULL = 1,		///< Full functionality (default on device power on).
-	DISABLED = 4	///< Disable phone both transmit and receive RF circuit.
+	RF_DISABLED = 4	///< Disable phone both transmit and receive RF circuit.
 };
 
 enum class SIM808_GPS_STATUS : int8_t

--- a/src/SIM808.cpp
+++ b/src/SIM808.cpp
@@ -28,7 +28,7 @@ void SIM808::init()
 	waitForReady();
 	delay(1500);
 
-	setEcho(SIM808_ECHO::OFF);
+	setEcho(SIM808Echo::OFF);
 }
 
 void SIM808::reset()
@@ -54,7 +54,7 @@ void SIM808::waitForReady()
 	while (waitResponse(TO_F(TOKEN_RDY)) != 0);
 }
 
-bool SIM808::setEcho(SIM808_ECHO mode)
+bool SIM808::setEcho(SIM808Echo mode)
 {
 	sendAT(S_F("E"), (uint8_t)mode);
 

--- a/src/SIM808.cpp
+++ b/src/SIM808.cpp
@@ -28,7 +28,7 @@ void SIM808::init()
 	waitForReady();
 	delay(1500);
 
-	setEcho(SIM808Echo::OFF);
+	setEcho(SIM808Echo::Off);
 }
 
 void SIM808::reset()

--- a/src/SIM808.cpp
+++ b/src/SIM808.cpp
@@ -2,7 +2,7 @@
 
 TOKEN(RDY);
 
-SIM808::SIM808(uint8_t resetPin, uint8_t pwrKeyPin = SIM808_UNAVAILABLE_PIN, uint8_t statusPin = SIM808_UNAVAILABLE_PIN)
+SIM808::SIM808(uint8_t resetPin, uint8_t pwrKeyPin, uint8_t statusPin)
 {
 	_resetPin = resetPin;
 	_pwrKeyPin = pwrKeyPin;

--- a/src/SIM808.h
+++ b/src/SIM808.h
@@ -33,7 +33,9 @@ private:
 	 */
 	bool readHttpResponse(char *response, size_t responseSize, size_t dataSize);	
 	bool setHttpParameter(ATConstStr parameter, ATConstStr value);
+#if defined(__AVR__)
 	bool setHttpParameter(ATConstStr parameter, const char * value);
+#endif
 	bool setHttpParameter(ATConstStr parameter, uint8_t value);
 	/**
 	 * Set the HTTP body of the next request to be fired.

--- a/src/SIM808.h
+++ b/src/SIM808.h
@@ -27,7 +27,7 @@ private:
 	/**
 	 * Fire a HTTP request and return the server response code and body size.
 	 */
-	bool fireHttpRequest(const SIM808_HTTP_ACTION action, uint16_t *statusCode, size_t *dataSize);
+	bool fireHttpRequest(const SIM808HttpAction action, uint16_t *statusCode, size_t *dataSize);
 	/**
 	 * Read the last HTTP response body into response.
 	 */
@@ -79,15 +79,15 @@ public:
 	/**
 	 * Get current phone functionality mode.
 	 */
-	SIM808_PHONE_FUNCTIONALITY getPhoneFunctionality();
+	SIM808PhoneFunctionality getPhoneFunctionality();
 	/**
 	 * Set the phone functionality mode.
 	 */
-	bool setPhoneFunctionality(SIM808_PHONE_FUNCTIONALITY fun);
+	bool setPhoneFunctionality(SIM808PhoneFunctionality fun);
 	/**
 	 * Configure slow clock, allowing the device to enter sleep mode.
 	 */
-	bool setSlowClock(SIM808_SLOW_CLOCK mode);
+	bool setSlowClock(SIM808SlowClock mode);
 
 	void init();
 	void reset();
@@ -97,7 +97,7 @@ public:
 	 */
 	size_t sendCommand(const char* cmd, char* response, size_t responseSize);
 
-	bool setEcho(SIM808_ECHO mode);
+	bool setEcho(SIM808Echo mode);
 	/**
 	 * Unlock the SIM card using the provided pin. Beware of failed attempts !
 	 */
@@ -116,7 +116,7 @@ public:
 	 */
 	SIM808SignalQualityReport getSignalQuality();
 
-	bool setSmsMessageFormat(SIM808_SMS_MESSAGE_FORMAT format);
+	bool setSmsMessageFormat(SIM808SmsMessageFormat format);
 	/**
 	 * Send a SMS to the provided number.
 	 */
@@ -137,7 +137,7 @@ public:
 	/**
 	 * Get the device current network registration status.
 	 */
-	SIM808_NETWORK_REGISTRATION_STATE getNetworkRegistrationStatus();
+	SIM808NetworkRegistrationState getNetworkRegistrationStatus();
 
 	/**
 	 * Get a boolean indicating wether or not GPS is currently powered on.
@@ -155,19 +155,19 @@ public:
 	 * If a fix is acquired, FIX or ACCURATE_FIX will be returned depending on 
 	 * wether or not the satellites used is greater than minSatellitesForAccurateFix.
 	 */
-	SIM808_GPS_STATUS getGpsStatus(char * response, size_t responseSize, uint8_t minSatellitesForAccurateFix = GPS_ACCURATE_FIX_MIN_SATELLITES);
+	SIM808GpsStatus getGpsStatus(char * response, size_t responseSize, uint8_t minSatellitesForAccurateFix = GPS_ACCURATE_FIX_MIN_SATELLITES);
 	/**
 	 * Extract the specified field from the GPS parsed sequence as a uint16_t.
 	 */
-	bool getGpsField(const char* response, SIM808_GPS_FIELD field, uint16_t* result);
+	bool getGpsField(const char* response, SIM808GpsField field, uint16_t* result);
 	/**
 	 * Extract the specified field from the GPS parsed sequence as a float.
 	 */
-	bool getGpsField(const char* response, SIM808_GPS_FIELD field, float* result);
+	bool getGpsField(const char* response, SIM808GpsField field, float* result);
 	/**
 	 * Return a pointer to the specified field from the GPS parsed sequence.
 	 */
-	void getGpsField(const char* response, SIM808_GPS_FIELD field, char** result);
+	void getGpsField(const char* response, SIM808GpsField field, char** result);
 	/**
 	 * Get and return the latest GPS parsed sequence.
 	 */

--- a/src/SIMComAT.cpp
+++ b/src/SIMComAT.cpp
@@ -151,6 +151,18 @@ bool SIMComAT::parse(const char* str, char divider, uint8_t index, uint16_t* res
 	return errno == 0;
 }
 
+#ifdef NEED_SIZE_T_OVERLOADS
+bool SIMComAT::parse(const char* str, char divider, uint8_t index, size_t* result) { 
+	char* p = find(str, divider, index);
+	if (p == NULL) return false;
+
+	errno = 0;
+	*result = strtoull(p, NULL, 10);
+	
+	return errno == 0; 
+}
+#endif
+
 bool SIMComAT::parse(const char* str, char divider, uint8_t index, int16_t* result)
 {	
 	char* p = find(str, divider, index);

--- a/src/SIMComAT.cpp
+++ b/src/SIMComAT.cpp
@@ -17,7 +17,7 @@ void SIMComAT::flushInput() {
 }
 
 
-size_t SIMComAT::readNext(char * buffer, size_t size, uint16_t * timeout = NULL, char stop = '\0')
+size_t SIMComAT::readNext(char * buffer, size_t size, uint16_t * timeout, char stop)
 {
 	size_t i = 0;
 	bool exit = false;
@@ -52,10 +52,10 @@ size_t SIMComAT::readNext(char * buffer, size_t size, uint16_t * timeout = NULL,
 }
 
 int8_t SIMComAT::waitResponse(uint16_t timeout, 
-	ATConstStr s1 = TO_F(TOKEN_OK),
-	ATConstStr s2 = TO_F(TOKEN_ERROR),
-	ATConstStr s3 = NULL,
-	ATConstStr s4 = NULL)
+	ATConstStr s1, 
+	ATConstStr s2,
+	ATConstStr s3,
+	ATConstStr s4)
 {
 	ATConstStr wantedTokens[4] = { s1, s2, s3, s4 };
 	size_t length;
@@ -78,7 +78,7 @@ int8_t SIMComAT::waitResponse(uint16_t timeout,
 	return -1;
 }
 
-size_t SIMComAT::copyCurrentLine(char *dst, size_t dstSize, uint16_t shift = 0)
+size_t SIMComAT::copyCurrentLine(char *dst, size_t dstSize, uint16_t shift)
 {
 	char *p = dst;
 	char *p1;

--- a/src/SIMComAT.cpp
+++ b/src/SIMComAT.cpp
@@ -151,7 +151,7 @@ bool SIMComAT::parse(const char* str, char divider, uint8_t index, uint16_t* res
 	return errno == 0;
 }
 
-#ifdef NEED_SIZE_T_OVERLOADS
+#if defined(NEED_SIZE_T_OVERLOADS)
 bool SIMComAT::parse(const char* str, char divider, uint8_t index, size_t* result) { 
 	char* p = find(str, divider, index);
 	if (p == NULL) return false;

--- a/src/SIMComAT.h
+++ b/src/SIMComAT.h
@@ -24,6 +24,10 @@
 	#define SENDARROW
 #endif // _DEBUG
 
+#if SIZE_MAX > UINT16_MAX
+	#define NEED_SIZE_T_OVERLOADS
+#endif
+
 #define BUFFER_SIZE 64
 #define SIMCOMAT_DEFAULT_TIMEOUT 1000
 
@@ -111,6 +115,12 @@ protected:
 	 * Parse the nth field of a string as a uint16_t.
 	 */
 	bool parse(const char* str, char divider, uint8_t index, uint16_t* result);
+#ifdef NEED_SIZE_T_OVERLOADS
+	/**
+	 * Parse the nth field of a string as a size_t.
+	 */
+	bool parse(const char* str, char divider, uint8_t index, size_t* result);
+#endif
 	/**
 	 * Parse the nth field of a string as a int16_t.
 	 */
@@ -132,6 +142,12 @@ protected:
 	 * Parse the nth field of the reply buffer as a uint16_t.
 	 */
 	bool parseReply(char divider, uint8_t index, uint16_t* result) { return parse(replyBuffer, divider, index, result); }
+#ifdef NEED_SIZE_T_OVERLOADS
+	/**
+	 * Parse the nth field of the reply buffer as a size_t.
+	 */
+	bool parseReply(char divider, uint8_t index, size_t* result) { return parse(replyBuffer, divider, index, result); }
+#endif	
 	/**
 	 * Parse the nth field of the reply buffer as a int16_t.
 	 */

--- a/src/SIMComAT.h
+++ b/src/SIMComAT.h
@@ -115,7 +115,7 @@ protected:
 	 * Parse the nth field of a string as a uint16_t.
 	 */
 	bool parse(const char* str, char divider, uint8_t index, uint16_t* result);
-#ifdef NEED_SIZE_T_OVERLOADS
+#if defined(NEED_SIZE_T_OVERLOADS)
 	/**
 	 * Parse the nth field of a string as a size_t.
 	 */
@@ -142,7 +142,7 @@ protected:
 	 * Parse the nth field of the reply buffer as a uint16_t.
 	 */
 	bool parseReply(char divider, uint8_t index, uint16_t* result) { return parse(replyBuffer, divider, index, result); }
-#ifdef NEED_SIZE_T_OVERLOADS
+#if defined(NEED_SIZE_T_OVERLOADS)
 	/**
 	 * Parse the nth field of the reply buffer as a size_t.
 	 */

--- a/src/SIMComAT.h
+++ b/src/SIMComAT.h
@@ -74,7 +74,7 @@ protected:
 	 * the stop character is encountered. timeout and char are optional
 	 * 
 	 */
-	size_t SIMComAT::readNext(char * buffer, size_t size, uint16_t * timeout = NULL, char stop = 0);
+	size_t readNext(char * buffer, size_t size, uint16_t * timeout = NULL, char stop = 0);
 	int8_t waitResponse(
 		ATConstStr s1 = TO_F(TOKEN_OK),
 		ATConstStr s2 = TO_F(TOKEN_ERROR),


### PR DESCRIPTION
This PR tends to improve compatibility with other platforms, especially the ESP32 family boards.

* Version bump to 2.0.0
* Renamed all enums from `SNAKE_CASE` to `PascalCase` to avoid possible macro conflicts
* Removed `setHttpParameter` overload for platforms without `PROGMEM`
* Additionnal `parse` and `parseReply`  overloads for platforms where `size_t` is larger than 16 bits (implicit cast to `uint16_t` is used otherwise)
* Removed optional parameters from cpp
* Fixed examples compilation

Fixes #6 
Fixes #9